### PR TITLE
Fixed some errors. Deleted accent when Upper Case.

### DIFF
--- a/es-ES.lproj/Front.strings
+++ b/es-ES.lproj/Front.strings
@@ -22,9 +22,9 @@
 
 /* Search Panel */
 "Search" = "Buscar";
-"Replace" = "Remplazar";
+"Replace" = "Reemplazar";
 "All" = "Todo";
-"Search text not found in article" = "El texto buscado no se ha encontrado en el artículo";
+"Search text not found in article" = "El texto a buscar no se ha encontrado en el artículo";
 "search text" = "buscar texto";
 
 /* Quick Open */
@@ -54,7 +54,7 @@
 
 /* Sidebar */
 "Articles" = "Artículos";
-"Outline" = "Índice";
+"Outline" = "Indice";
 "Files" = "Archivos";
 "Switch to File List view" = "Cambiar a vista de lista de archivos";
 "Switch to File Tree view" = "Cambiar a vista de árbol de archivos";
@@ -68,7 +68,7 @@
 "Action" = "Acción"; /* Needs more context */
 "Close Sidebar Menu" = "Cerrar menú de barra lateral";
 "Reveal in Finder" = "Mostrar en el Finder";
-"Reveal in File Explorer" = "Mostrar en el Explorador de Archivos";
+"Reveal in File Explorer" = "Mostrar en el explorador de Archivos";
 "Refresh Folder" = "Recargar carpeta";
 "Sort" = "Ordenar";
 "Group By Folder" = "Agrupar por carpeta";
@@ -80,7 +80,7 @@
 "Switch File List/Tree View" = "Cambiar entre vista de lista/árbol de archivos";
 "No Files Available" = "No hay archivos disponibles";
 "No Folder is Opened." = "Ninguna carpeta abierta.";
-"Outline is Empty." = "Índice vacío.";
+"Outline is Empty." = "Indice vacío.";
 
 /* Status Bar */
 "Toggle Sidebar" = "Alternar barra lateral";
@@ -102,7 +102,7 @@
 "Folder does not exist at %@" = "La carpeta no existe en %@";
 "File with the same name already exists at target path" = "Un archivo con el mismo nombre ya existe en la ruta de destino";
 "Apply to All" = "Aplicar a todo";
-"Overwrite" = "Sobrescribir";
+"Overwrite" = "Sobreescribir";
 "Stop" = "Detener";
 "back to document" = "volver al documento";
 "Failed to load file" = "Error al cargar el archivo";

--- a/es-ES.lproj/Menu.strings
+++ b/es-ES.lproj/Menu.strings
@@ -29,7 +29,7 @@
 "No Recent Files" = "No hay archivos recientes";
 "Open Quickly" = "Arbir rápidamente";
 "Open File Location" = "Abrir ubicación del archivo";
-"Reveal in Library" = "Mostrar como Librería"; /* Needs context */
+"Reveal in Library" = "Mostrar como librería"; /* Needs context */
 "Reveal in File Tree" = "Mostrar como árbol de archivos";
 "Close" = "Cerrar";
 "Save" = "Guardar";
@@ -55,7 +55,7 @@
 "Copy as HTML Code" = "Copiar como código HTML";
 "Paste as Plain Text" = "Pegar como texto plano";
 "Select All" = "Seleccionar todo";
-"Select Line/Sentence" = "Seleccionar línea/sentencia";
+"Select Line/Sentence" = "Seleccionar línea/frase";
 "Select Styled Scope" = "Selecionar todo con ese estilo";
 "Select Word" = "Seleccionar palabra";
 "Delete" = "Eliminar";
@@ -68,11 +68,11 @@
 "Jump to Selection" = "Saltar a selección";
 "Jump to Bottom" = "Saltar a abajo";
 "Math Tools" = "Herramientas matemáticas";
-"Refresh All Math Expressions" = "Recargar todas las expresiones matemáticas";
+"Refresh All Math Expressions" = "Actualizar todas las expresiones matemáticas";
 "Image Tools" = "Herramientas de imagen";
 "Insert Local Images" = "Insertar imágenes locales";
 "Upload Local Images via iPic" = "Cargar imágenes vía iPic";
-"When Insert Local Image" = "Cuando se insertar una imagen local";
+"When Insert Local Image" = "Cuando insertar una imagen local";
 "Copy Image File to Folder" = "Copiar archivo de imagen a carpeta";
 "Upload Image via iPic" = "Cargar imagen vía iPic";
 "Use Image Root Path" = "Usar ruta principal de la imagen";
@@ -81,10 +81,10 @@
 "Unix Line Endings (LF)" = "Finales de línea de Unix (LF)";
 "Find" = "Buscar";
 "Find Next" = "Buscar siguiente";
-"Find Previous" = "Buscar anterio";
-"Find and Replace" = "Buscar y remplazar";
-"Replace" = "Remplazar";
-"Replace Next" = "Remplazar siguiente";
+"Find Previous" = "Buscar anterior";
+"Find and Replace" = "Buscar y reemplazar";
+"Replace" = "Reemplazar";
+"Replace Next" = "Reemplazar siguiente";
 "Spelling and Grammar" = "Ortografía y gramática";
 "Check Document Now" = "Comprobar documento ahora";
 "Check Spelling While Typing" = "Comprobar ortografía mientras se escribe";
@@ -93,7 +93,7 @@
 "Substitutions" = "Sustituciones";
 "Smart Quotes" = "Frases inteligentes";
 "Smart Dashes" = "Guiones inteligentes";
-"Text Replacement" = "Remplazo de texto";
+"Text Replacement" = "Reemplazo de texto";
 "Speech" = "Voz";
 "Start Speaking" = "Leer en voz alta";
 "Stop Speaking" = "Detener lectura en voz alta";

--- a/es-ES.lproj/Panel.strings
+++ b/es-ES.lproj/Panel.strings
@@ -54,9 +54,9 @@
 
 /* Markdown Panel */
 "Markdown" = "Markdown";
-"(Following preferences will be applied after restart.)" = "(Las siguientes preferencias serán aplicadas despúes de reiniciar.)";
+"(Following preferences will be applied after restart.)" = "(Las siguientes preferencias serán aplicadas después de reiniciar.)";
 "Syntax Support" = "Soporte de sintaxis";
-"Inline Math  ( e.g: $\LaTeX$ )" = "Ecuación embebida  ( ej.: $\LaTeX$ )";
+"Inline Math  ( e.g: $\LaTeX$ )" = "Ecuación en línea  ( ej.: $\LaTeX$ )";
 "Subscript    ( e.g: H~2~O )" = "Subíndice    ( ej.: H~2~O )";
 "Superscript ( e.g: X^2^ )" = "Superíndice ( ej.: X^2^ )";
 "Highlight     (e.g: ==key==)" = "Subrayado     (e.g: ==key==)";
@@ -142,10 +142,10 @@
 "Emoji Autocomplete" = "Autocompletado de emoji";
 "Trigger by ESC key" = "Al oprimir en la tecla ESC";
 "Trigger automatically" = "Automático";
-"Default Line Ending" = "Terminación de línea predeterminada";
+"Default Line Ending" = "Fin de línea predeterminada";
 "Line ending for new file" = "Fin de línea para nuevos archivos";
 "Spell Check" = "Revisar ortografía";
-"(support US English only)" = "(solo soportado en Inglés de EEUU)";
+"(support US English only)" = "(solo soportado en inglés de EEUU)";
 "Enable spell check" = "Habilitar revisión de gramática";
 "Auto correct spelling" = "Autocorregir gramática";
 "System" = "Sistema";


### PR DESCRIPTION
Fixed errors I encountered.
Deleted accents at upper case letters, since we don't really use it when upper case. Both are grammatically correct. 