### PR TITLE
Update Japanese Translation

### DIFF
--- a/ja-JP.lproj/Menu.strings
+++ b/ja-JP.lproj/Menu.strings
@@ -35,7 +35,7 @@
 "Open Recent" = "最近使ったファイル";
 "Clear Items" = "履歴を消去";
 "No Recent Files" = "履歴なし";
-"Open Quickly" = "高速で開く";
+"Open Quickly" = "すぐに開く";
 "Open File Location" = "ファイルのある場所を開く";
 "Reveal in Library" = "ライブラリに表示する";
 "Reveal in File Tree" = "ファイルツリーに表示";


### PR DESCRIPTION
I find the translation of "Open Quickly" into "高速で開く" strange, because in Japanese "高速で開く" actually means "Open at High Speed". 
Instead "すぐに開く" might be better.