### PR TITLE
Fix typo in pl_PL Front.strings

### DIFF
--- a/pl-PL.lproj/Panel.strings
+++ b/pl-PL.lproj/Panel.strings
@@ -72,7 +72,7 @@
 "Code Fences" = "Bloki kodu";
 "Display line numbers for code fences" = "Wyświetlaj numerację linijek w \nblokach kodu";
 "Math Blocks" = "Bloki matematyczne";
-"Auto Numbering Math Equations" = "Autmatyczne numerowanie równań \nmatematycznych";
+"Auto Numbering Math Equations" = "Automatyczne numerowanie równań \nmatematycznych";
 
 /* Security Panel */
 "Security" = "Bezpieczeństwo";


### PR DESCRIPTION
Missing 'o' letter was added in word 'Automatyczne'