### PR TITLE
fix: typo in translation of 'disk'

### DIFF
--- a/nl-NL.lproj/Front.strings
+++ b/nl-NL.lproj/Front.strings
@@ -68,7 +68,7 @@
 "Unpin Outline Panel" = "Overzichtspaneel losspelden";
 "Open Folder..." = "Open Map...";
 "Action" = "Actie";
-"Close Sidebar Menu" = "Sluit zijmenu";
+"Close Sidebar Menu" = "Sluit zijbalk";
 "Reveal in Finder" = "Openen in Finder";
 "Reveal in File Explorer" = "Openen in Bestandsverkenner";
 "Refresh Folder" = "Map verversen";
@@ -110,7 +110,7 @@
 "Save File Failed!" = "Mislukt om bestand op te slaan!";
 "Cannot open folder {0}" = "Kan map niet openen {0}";
 
-"File content is changed by external applications. Reload content from disk ?" = "Bestandsinhoud is aangepast door een externe applicatie. Herladen van schrijf?";
+"File content is changed by external applications. Reload content from disk ?" = "Bestandsinhoud is aangepast door een externe applicatie. Herladen van schijf?";
 "Should continue moving and overwrite exisiting file(s) ?" = "Doorgaan met het verplaatsen en overschrijven van bestaande bestand(en) ?";
 
 "Rename Failed" = "Hernoemen mislukt";
@@ -133,4 +133,4 @@
 "Whole Word" = "Heel Woord";
 
 "input image URL" = "voer afbeeldings URL in";
-"Select image from local file" = "Selecteer afbeelding van locale schrijf";
+"Select image from local file" = "Selecteer afbeelding van locale schijf";


### PR DESCRIPTION
Make the translation of sidebar consistent