### PR TITLE
“标签” is ambiguous, use “标签页” instead

### DIFF
--- a/zh-Hans.lproj/Menu.strings
+++ b/zh-Hans.lproj/Menu.strings
@@ -147,7 +147,7 @@
 
 /* View Menu */
 "View" = "显示";
-"New Tab" = "新建标签";
+"New Tab" = "新建标签页";
 "Source Code Mode" = "源代码模式";
 "Focus Mode" = "专注模式";
 "Typewriter Mode" = "打字机模式";


### PR DESCRIPTION
In Chinese Simplified, the word 标签 can mean either tab or tag, so prefer to use 新建标签页 as the translation of menu "New Tab".