### PR TITLE
[ko-KR] Fix typo

### DIFF
--- a/ko-KR.lproj/Front.strings
+++ b/ko-KR.lproj/Front.strings
@@ -5,7 +5,7 @@
  by hi@typora.io
 
  Korean translation
- by ryush00, Third9
+ by ryush00, Third9, cog25
 */
 
 /* Common */

--- a/ko-KR.lproj/Front.strings
+++ b/ko-KR.lproj/Front.strings
@@ -55,16 +55,16 @@
 
 /* Sidebar */
 "Articles" = "문서";
-"Outline" = "개략";
+"Outline" = "개요";
 "Files" = "파일";
 "Switch to File List view" = "파일 목록 보기로 전환";
 "Switch to File Tree view" = "파일 트리 보기로 전환";
-"Switch to Outline view" = "개략 보기로 전환";
+"Switch to Outline view" = "개요 보기로 전환";
 "Close sidebar" = "사이드바 닫기";
 "Loading" = "로드중";
 "Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "선택된 폴더의 파일이 너무 많습니다. \n 더 나은 성능을 위해 <a id='switch-to-tree-on-oversize'>파일 트리 보기</a>로 전환하세요.";
 "New File" = "새 파일";
-"Unpin Outline Panel" = "개략 패널 고정 해제";
+"Unpin Outline Panel" = "개요 패널 고정 해제";
 "Open Folder..." = "폴더 열기...";
 "Action" = "동작";
 "Close Sidebar Menu" = "사이드바 메뉴 닫기";
@@ -82,7 +82,7 @@
 "Switch File List/Tree View" = "목록/트리 보기로 전환";
 "No Files Available" = "사용 가능한 파일 없음";
 "No Folder is Opened." = "열린 폴더가 없음.";
-"Outline is Empty." = "개략이 비어있음.";
+"Outline is Empty." = "개요이 비어있음.";
 
 /* Status Bar */
 "Toggle Sidebar" = "사이드바 토글";

--- a/ko-KR.lproj/Menu.strings
+++ b/ko-KR.lproj/Menu.strings
@@ -5,7 +5,7 @@
  by hi@typora.io
 
  Korean translation
- by ryush00, vreality64, Third9, IdionKim
+ by ryush00, vreality64, Third9, IdionKim, cog25
 */
 
 /* Typora Menu */

--- a/ko-KR.lproj/Menu.strings
+++ b/ko-KR.lproj/Menu.strings
@@ -155,7 +155,7 @@
 "Focus Mode" = "포커스 모드";
 "Typewriter Mode" = "타자기 모드";
 "Toggle Sidebar" = "사이드바 토글";
-"Outline" = "개략";
+"Outline" = "개요";
 "Articles" = "문서";
 "File Tree" = "파일 트리";
 "Always on Top" = "항상 위에";

--- a/ko-KR.lproj/Panel.strings
+++ b/ko-KR.lproj/Panel.strings
@@ -27,8 +27,8 @@
 "Customized" = "사용자화";
 "If custom font size is used, the actual font size will depend on the base font size and css style." = "서체 크기를 사용자화하면 기본 서체 크기 및 CSS 스타일에 따라 실제 글씨 크기가 달라집니다.";
 "Left Panel" = "왼쪽 패널";
-"Show Outline Panel by Default" = "개략 패널 기본 표시";
-"Collapsible Outline on Left Panel" = "접을 수 있는 왼쪽 개략 패널";
+"Show Outline Panel by Default" = "개요 패널 기본 표시";
+"Collapsible Outline on Left Panel" = "접을 수 있는 왼쪽 개 패널";
 "Save without asking when\nswitch files on side panel" = "사이드 패널에서 파일 전환시\n묻지 않고 저장";
 "Language" = "언어";
 "System Language" = "시스템 언어";

--- a/ko-KR.lproj/Panel.strings
+++ b/ko-KR.lproj/Panel.strings
@@ -5,7 +5,7 @@
  by hi@typora.io
 
  Korean translation
- by ryush00, Third9, cozyplanes
+ by ryush00, Third9, cozyplanes, cog25
  */
 
 /* Preference Panel */


### PR DESCRIPTION
한국어에서, `Outline`은 `개략`보다는 `개요`가 더 자연스러운 표현이라 생각해, 변경하였습니다.