### PR TITLE
Update Indonesian Translation According to KBBI and PUEBI

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ Feel free to contact us via <hi@typora.io>
 - Catalan by [jmigual](https://github.com/jmigual)
 - Danish by [archfrog](https://github.com/archfrog)
 - Persian by [sadra](https://github.com/sadra)
-- Indonesian by [snatalius](https://github.com/snatalius), [Kylamber](https://github.com/Kylamber)
+- Indonesian by [snatalius](https://github.com/snatalius), [Kylamber](https://github.com/Kylamber), [nashrullahalifauzi](https://github.com/nashrullahalifauzi)
 - Dutch by Melle Dijkstra, [vidavidorra](https://github.com/vidavidorra), [andredelft](https://github.com/andredelft)
 - Slovak by Petr Mátl
 - Ukrainian by [oleksavyshnivsky](https://github.com/oleksavyshnivsky)

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -127,7 +127,7 @@
 "Save File Failed!" = "Simpan Berkas Gagal!";
 "Cannot open folder {0}" = "Takdapat membuka folder {0}";
 
-"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> */
+"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> or <http://tesaurus.kemdikbud.go.id/tematis/lema/diska> */
 "Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan berkas yang eksis ?";
 
 "Rename to \"{0}\" ?" = "Ubah nama ke \"{0}\" ?";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -83,8 +83,8 @@
 "Open Folder..." = "Buka Folder...";
 "Action" = "Aksi";
 "Close Sidebar Menu" = "Tutup Menu Bilahsisi";
-"Reveal in Finder" = "Tampilkan di Finder";
-"Reveal in File Explorer" = "Tampilkan di Eksplorasi Fail";
+"Reveal in Finder" = "Tunjukkan di Penemu"; /* `Finder` as `Penemu`, `find` as `temu` see <https://kbbi.kemdikbud.go.id/entri/penemu> */
+"Reveal in File Explorer" = "Tunjukkan di Eksplorasi Fail";
 "Refresh Folder" = "Kembalisegarkan Folder";
 "Sort" = "Sortir";
 "Group By Folder" = "Grup Berdasarkan Folder";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -127,7 +127,7 @@
 "Save File Failed!" = "Simpan Berkas Gagal!";
 "Cannot open folder {0}" = "Takdapat membuka folder {0}";
 
-"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari disk?";
+"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> */
 "Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan berkas yang eksis ?";
 
 "Rename to \"{0}\" ?" = "Ubah nama ke \"{0}\" ?";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -105,7 +105,7 @@
 "Toggle Source Code Mode" = "(Non-)aktifkan Mode Source Code";
 "Exit Source Code Mode" = "Keluar dari Mode Kode Sumber";
 
-"Table of Contents" = "Daftar Isi";
+"Table of Contents" = "Tabel Konten";
 "Empty Diagram" = "Diagram Kosong";
 "Input Math TeX here" = "Masukkan TeX Matematika di sini";
 

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -1,5 +1,4 @@
 /*
-
   Front.strings
   Typora
 
@@ -19,7 +18,6 @@
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
   Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
-
 */
 
 /* Common */
@@ -60,7 +58,7 @@
 "Delete Table" = "Hapus Tabel";
 
 /* Images */
-"Typora are trying copy the newly inserted image to folder <code id='image-create-folder-target'></code> according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru disisipkan ke folder <code id='image-create-folder-target'></code> sesuai dengan aturan YAML Front Matter atau preferensi global. Namun, folder tujuan tidak eksis. Buat folder tersebut sekarang?";
+"Typora are trying copy the newly inserted image to folder <code id='image-create-folder-target'></code> according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru disisipkan ke folder <code id='image-create-folder-target'></code> sesuai dengan setelan YAML Front Matter atau preferensi global. Namun, folder tujuan tidak eksis. Buat folder tersebut sekarang?";
 "Create Folder" = "Buat Folder";
 
 /* Math */
@@ -70,22 +68,22 @@
 
 /* Sidebar */
 "Articles" = "Artikel";
-"Outline" = "Ikhtisar"; /* See <http://tesaurus.kemdikbud.go.id/tematis/lema/ikhtisar> */
+"Outline" = "Garisbesar"; /* Must be coupled, `Garisbesar`, not `Garis besar`, see <http://tesaurus.kemdikbud.go.id/tematis/lema/garis%2Bbesar> */
 "Files" = "Fail";
 "Switch to File List view" = "Alihkan ke tinjauan Daftar Fail";
 "Switch to File Tree view" = "Alihkan ke tinjauan Pohon Fail";
-"Switch to Outline view" = "Alihkan ke tinjauan Ikhtisar";
+"Switch to Outline view" = "Alihkan ke tinjauan Garisbesar";
 "Close sidebar" = "Tutup bilahsisi";
 "Loading" = "Memuat";
-"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak fail. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tinjauan Pohon Fail</a> untuk kinerja yang lebih baik.";
+"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak fail. \nSilakan ubah ke <a id='switch-to-tree-on-oversize'>tinjauan Pohon Fail</a> untuk kinerja yang lebih baik.";
 "New File" = "Fail Baru";
-"Unpin Outline Panel" = "Takpinkan Panel Ikhtisar";
+"Unpin Outline Panel" = "Takpinkan Panel Garisbesar";
 "Open Folder..." = "Buka Folder...";
 "Action" = "Aksi";
 "Close Sidebar Menu" = "Tutup Menu Bilahsisi";
 "Reveal in Finder" = "Tunjukkan di Penemu"; /* `Finder` as `Penemu`, `find` as `temu` see <https://kbbi.kemdikbud.go.id/entri/penemu> */
 "Reveal in File Explorer" = "Tunjukkan di Eksplorasi Fail";
-"Refresh Folder" = "Kembalisegarkan Folder";
+"Refresh Folder" = "Segarulangkan Folder";
 "Sort" = "Sortir";
 "Group By Folder" = "Grup Berdasarkan Folder";
 "Sort Naturally" = "Sortir secara Natural";
@@ -98,7 +96,7 @@
 "Switch File List/Tree View" = "Alihkan Tinjauan Daftar/Pohon Fail";
 "No Files Available" = "Tiada Fail yang Tersedia";
 "No Folder is Opened." = "Tiada Folder yang Terbuka.";
-"Outline is Empty." = "Ikhtisar Kosong.";
+"Outline is Empty." = "Garisbesar Kosong.";
 
 /* Status Bar */
 "Toggle Sidebar" = "(Non-)aktifkan Bilah Sisi";
@@ -111,12 +109,12 @@
 
 "Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Perlu mendefinisikan referensi catatan kaki <b>{0}</b> dengan sintaksis <a>[^{1}]: www.example.com</a>";
 "Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Perlu mendefinisikan referensi pranala <b>[{0}]</b> dengan sintaks <b>[{1}]: www.example.com</b>";
-"Please define image reference by \n[{0}]: http://example.png" = "Sila definisikan referensi gambar dengan \n[{0}]: http://example.png"; /* `Link` as `pranala`, see <https://kbbi.kemdikbud.go.id/entri/pranala> */
+"Please define image reference by \n[{0}]: http://example.png" = "Silakan definisikan referensi gambar dengan \n[{0}]: http://example.png"; /* `Link` as `pranala`, see <https://kbbi.kemdikbud.go.id/entri/pranala> */
 
 /* msg */
 "Failed to create file" = "Gagal membuat fail";
 "Failed to create folder" = "Gagal membuat folder";
-"Failed to rename file" = "Gagal ubah nama fail";
+"Failed to rename file" = "Gagal namaiulang fail";
 "Folder does not exist at %@" = "Folder tidak eksis di %@";
 "File with the same name already exists at target path" = "Fail dengan nama yang sama telah ada di target jalur";
 "Apply to All" = "Terapkan untuk Semua";
@@ -130,8 +128,8 @@
 "File content is changed by external applications. Reload content from disk ?" = "Konten fail diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> or <http://tesaurus.kemdikbud.go.id/tematis/lema/diska> */
 "Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan fail yang eksis ?";
 
-"Rename to \"{0}\" ?" = "Ubah nama ke \"{0}\" ?";
-"Failed to rename from \"{0}\" to \"{1}\"" = "Gagal mengubah nama dari \"{0}\" ke \"{1}\"";
+"Rename to \"{0}\" ?" = "Namaiulang ke \"{0}\" ?";
+"Failed to rename from \"{0}\" to \"{1}\"" = "Gagal namaiulang dari \"{0}\" ke \"{1}\"";
 
 /* Image upload & move */
 "Successfully uploaded {0} images." = "Berhasil mengunggah {0} gambar.";
@@ -160,7 +158,7 @@
 "Select Spell Check Language" = "Seleksi Cek Ejaan Bahasa";
 "Auto Detect Language" = "Oto Deteksi Bahasa"; /* `auto` as `oto`; `automatize` as `otomatis` */
 "Disable Spell Check" = "Nonaktifkan Cek Ejaan";
-"Global Setting…" = "Pengaturan Global…";
+"Global Setting…" = "Setelan Global…";
 "Dictionary file is missing to enable spellcheck support for %@." = "Fail kamus tak tersedia untuk mengaktifkan cek ejaan untuk %@.";
 "Install Language Support" = "Instal Dukungan Bahasa"; /* See <https://kbbi.kemdikbud.go.id/entri/instalasi> */
 "License Information" = "Informasi Lisensi";
@@ -184,3 +182,23 @@
 "The file is read-only, or you do not have right permissions to modify the file." = "Fail tersedia baca-saja, atau Anda tidak punya izin untuk mengubah fail tersebut.";
 
 "Learn Data Recovery" = "Pelajari Pemulihan Data";
+"Auto refresh on Files Panel cannot be enabled." = "Oto segarulang pada Panel Fail tidak dapat diaktifkan.";
+"Delete Permanently" = "Hapus Permanen";
+
+
+"Failed to upload images:" = "Gagal mengunggah gambar:";
+"Uploading in progress" = "Pengunggahan dalam progres";
+"Successfully uploaded {0} images, {1} failed." = "Sukses penuh diunggah {0} gambar, {1} gagal.";
+
+"You could undo this operation later via `Edit` → `Undo`." = "Anda dapat membatalkan operasi ini nanti via `Edit` → `Takjadi`.";
+
+"You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "Anda dapat menekan <strong>⌘ + Klik</strong> untuk membuka <a href='#'>links</a> atau lompat ke definisi catatan kaki.";
+"You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "Anda dapat menekan <strong>CTRL + Klik</strong> untuk membuka <a href='#'>pranala</a> atau lompat ke definisi catatan kaki.";
+
+"<strong>Unibody</strong> style has been turned on." = "Gaya <strong>Unibodi</strong> telah diaktifkan.";
+"You can right click titlebar to popup application menu." = "Anda dapat mengklik kanan bilah judul untuk memunculkan menu aplikasi.";
+
+"Support Document" = "Dokumen Pendukung";
+
+"You are not supposed to edit or save this file." = "Anda tidak seharusnya mengedit atau menyimpan fail ini.";
+"Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing." = "Fail di lokasi ini (%@) dikelola oleh Typora, dan dapat dihapus secara otomatis.<br/>Silakan salin konten ke fail baru untuk pengeditan lebih lanjut.";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -1,38 +1,51 @@
 /*
+
   Front.strings
   Typora
 
  by hi@typora.io
 
- Indonesian (Bahasa Indonesia) translation
- by Samuel Natalius (@snatalius)
- samnatalius[at]outlook[dot]com
+ Indonesian (Bahasa Indonesia) Translation
+ by Samuel Natalius <https://github.com/snatalius> <samnatalius@outlook.com>,
+    Kylamber <https://github.com/Kylamber> <>,
+    Nashrullah Ali Fauzi <https://github.com/nashrullahalifauzi> <nash@nashrullahalifauzi.com>.
+
+  Notice:
+
+  If there is an loanword in the Indonesian dictionary, then use it in Typora. For example, if in English there is the word `font`, then in standard Indonesian it should be written `fon` without the letter `t`, even though there is a non-standard word, `fonta` which has the same meaning.
+
+  Likewise with the word 'input' in English, when it is translated into Indonesian it does not change, because the word 'input' in the Indonesian dictionary, also has the same meaning in English. It is not appropriate to translate the English word 'input' as 'masukan' in Indonesian. This is an attempt to keep the language of the app, especially Typora, from straying too far from its native language as default.
+
+  `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
+
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+
 */
 
 /* Common */
-"OK" = "OK";
+"OK" = "Setuju"; /* See <https://kbbi.kemdikbud.go.id/entri/setuju> as standard word and/or <https://kbbi.kemdikbud.go.id/entri/oke>, but `oke` its non-standard word. */
 "Cancel" = "Batalkan";
 "Yes" = "Ya";
 "No" = "Tidak";
 "Close" = "Tutup";
-"Select" = "Pilih";
-"Continue" = "Lanjut";
-"Learn More…" = "Pelajari Lebih Lanjut…";
-"Untitled" = "Tanpa Judul";
-"Undo" = "Kembali";
+"Select" = "Seleksi"; /* See <https://kbbi.kemdikbud.go.id/entri/seleksi> */
+"Continue" = "Lanjutkan";
+"Learn More…" = "Pelajari Lagi…";
+"Untitled" = "Takberjudul"; /* Learn <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf> */
+"Undo" = "Takjadi"; /* Learn <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf> */
 "Dismiss" = "Hentikan";
-"Confirm" = "Konfirmasi";
-"Error" = "Kesalahan";
+"Confirm" = "Konfirmasikan";
+"Error" = "Eror; /* See <https://kbbi.kemdikbud.go.id/entri/eror> */
 
 /* Search Panel */
 "Search" = "Cari";
 "Replace" = "Ganti";
 "All" = "Semua";
-"Search text not found in article" = "Teks pencarian tidak ditemukan pada artikel";
-"search text" = "Teks pencarian";
+"Search text not found in article" = "Pencarian teks tak ditemukan dalam artikel";
+"search text" = "pencarian teks";
 
 /* Quick Open */
-"Search by file name" = "Cari dengan nama file";
+"Search by file name" = "Cari berdasarkan nama berkas";
 "Searching" = "Sedang mencari";
 "Gathering more results" = "Mengumpulkan lebih banyak hasil";
 
@@ -47,84 +60,84 @@
 "Delete Table" = "Hapus Tabel";
 
 /* Images */
-"Typora are trying copy the newly inserted image to folder <code id='image-create-folder-target'></code> according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora sedang berusaha untuk menyalin gambar yang baru disisipkan ke folder <code id='image-create-folder-target'></code> sesuai dengan aturan YAML Front Matter atau preferensi global Anda. Namun, folder tujuan belum ada. Buat folder tersebut sekarang?";
+"Typora are trying copy the newly inserted image to folder <code id='image-create-folder-target'></code> according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru disisipkan ke folder <code id='image-create-folder-target'></code> sesuai dengan aturan YAML Front Matter atau preferensi global. Namun, folder tujuan tidak eksis. Buat folder tersebut sekarang?";
 "Create Folder" = "Buat Folder";
 
 /* Math */
-"Edit" = "Edit";
+"Edit" = "Sunting";
 "Delete Math" = "Hapus Matematika";
 "Preview" = "Pratinjau";
 
 /* Sidebar */
 "Articles" = "Artikel";
-"Outline" = "Ikhtisar";
-"Files" = "File";
-"Switch to File List view" = "Ubah ke tinjauan Daftar File";
-"Switch to File Tree view" = "Ubah ke tinjauan Pohon File";
-"Switch to Outline view" = "Ubah ke tinjauan Ikhtisar";
-"Close sidebar" = "Tutup bilah sisi";
-"Loading" = "Sedang memuat";
-"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak file. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tampilan Pohon File</a> untuk kinerja yang lebih baik.";
-"New File" = "File Baru";
-"Unpin Outline Panel" = "Lepaskan sematan Panel Ikhtisar";
+"Outline" = "Ikhtisar"; /* See <http://tesaurus.kemdikbud.go.id/tematis/lema/ikhtisar> */
+"Files" = "Berkas";
+"Switch to File List view" = "Alihkan ke tampilan Daftar Berkas";
+"Switch to File Tree view" = "Alihkan ke tampilan Pohon Berkas";
+"Switch to Outline view" = "Alihkan ke tampilan Ikhtisar";
+"Close sidebar" = "Tutup bilahsisi";
+"Loading" = "Memuat";
+"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak berkas. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tampilan Pohon Berkas</a> untuk kinerja yang lebih baik.";
+"New File" = "Berkas Baru";
+"Unpin Outline Panel" = "Takpinkan Panel Ikhtisar";
 "Open Folder..." = "Buka Folder...";
 "Action" = "Aksi";
-"Close Sidebar Menu" = "Tutup Menu Bilah Sisi";
+"Close Sidebar Menu" = "Tutup Menu Bilahsisi";
 "Reveal in Finder" = "Tampilkan di Finder";
-"Reveal in File Explorer" = "Tampilkan di File Explorer";
-"Refresh Folder" = "Muat Ulang Folder";
-"Sort" = "Urut";
-"Group By Folder" = "Kumpulkan menurut Folder";
-"Sort Naturally" = "Urutkan secara Alami";
-"Sort by Name (Ascending)" = "Urutkan berdasarkan Nama (Urut Naik)";
-"Sort by Modification Date (Ascending)" = "Urutkan berdasarkan Tanggal Perubahan (Urut Naik)";
-"Sort by Name (Descending)" = "Urutkan berdasarkan Nama (Urut Turun)";
-"Sort by Modification Date (Descending)" = "Urutkan berdasarkan Tanggal Perubahan (Urut Turun)";
+"Reveal in File Explorer" = "Tampilkan di Eksplorasi Berkas";
+"Refresh Folder" = "Kembalisegarkan Folder";
+"Sort" = "Sortir";
+"Group By Folder" = "Grup Berdasarkan Folder";
+"Sort Naturally" = "Sortir secara Natural";
+"Sort by Name (Ascending)" = "Sortir berdasarkan Nama (Naik)";
+"Sort by Modification Date (Ascending)" = "Sortir berdasarkan modifikasi Tanggal (Naik)";
+"Sort by Name (Descending)" = "Sortir berdasarkan Nama (Turun)";
+"Sort by Modification Date (Descending)" = "Sortir berdasarkan modifikasi Tanggal (Turun)";
 "Recent Locations" = "Lokasi Terkini";
 "Location" = "Lokasi";
-"Switch File List/Tree View" = "Ubah ke Tinjauan Daftar/Pohon File";
-"No Files Available" = "Tidak Ada File yang Tersedia";
-"No Folder is Opened." = "Tidak Ada Folder yang Terbuka.";
+"Switch File List/Tree View" = "Alihkan Tampilan Daftar/Pohon Berkas";
+"No Files Available" = "Tiada Berkas yang Tersedia";
+"No Folder is Opened." = "Tiada Folder yang Terbuka.";
 "Outline is Empty." = "Ikhtisar Kosong.";
 
 /* Status Bar */
 "Toggle Sidebar" = "(Non-)aktifkan Bilah Sisi";
 "Toggle Source Code Mode" = "(Non-)aktifkan Mode Source Code";
-"Exit Source Code Mode" = "Keluar dari Mode Source Code";
+"Exit Source Code Mode" = "Keluar dari Mode Kode Sumber";
 
 "Table of Contents" = "Daftar Isi";
 "Empty Diagram" = "Diagram Kosong";
 "Input Math TeX here" = "Masukkan TeX Matematika di sini";
 
-"Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Pendefinisian catatan kaki sumber <b>{0}</b> harus dengan format <a>[^{1}]: www.example.com</a>";
-"Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Pendefinisian tautan sumber <b>[{0}]</b> harus dengan format <b>[{1}]: www.example.com</b>";
-"Please define image reference by \n[{0}]: http://example.png" = "Mohon mendefinisikan referensi gambar dengan format \n[{0}]: http://example.png";
+"Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Perlu mendefinisikan referensi catatan kaki <b>{0}</b> dengan sintaksis <a>[^{1}]: www.example.com</a>";
+"Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Perlu mendefinisikan referensi pranala <b>[{0}]</b> dengan sintaks <b>[{1}]: www.example.com</b>";
+"Please define image reference by \n[{0}]: http://example.png" = "Sila definisikan referensi gambar dengan \n[{0}]: http://example.png"; /* `Link` as `pranala`, see <https://kbbi.kemdikbud.go.id/entri/pranala> */
 
 /* msg */
-"Failed to create file" = "Gagal membuat file";
+"Failed to create file" = "Gagal membuat berkas";
 "Failed to create folder" = "Gagal membuat folder";
-"Failed to rename file" = "Gagal mengubah nama file";
-"Folder does not exist at %@" = "Folder tidak ada di %@";
-"File with the same name already exists at target path" = "File dengan nama yang sama telah ada di path tujuan";
+"Failed to rename file" = "Gagal ubah nama berkas";
+"Folder does not exist at %@" = "Folder tidak eksis di %@";
+"File with the same name already exists at target path" = "Berkas dengan nama yang sama telah ada di target jalur";
 "Apply to All" = "Terapkan untuk Semua";
 "Overwrite" = "Timpa";
-"Stop" = "Hentikan";
+"Stop" = "Stop"; /* See <https://kbbi.kemdikbud.go.id/entri/stop> */
 "back to document" = "kembali ke dokumen";
-"Failed to load file" = "Gagal memuat file";
-"Save File Failed!" = "Gagal menyimpan file!";
-"Cannot open folder {0}" = "Tidak dapat membuka folder {0}";
+"Failed to load file" = "Gagal memuat berkas";
+"Save File Failed!" = "Simpan Berkas Gagal!";
+"Cannot open folder {0}" = "Takdapat membuka folder {0}";
 
-"File content is changed by external applications. Reload content from disk ?" = "Isi file diganti oleh aplikasi luar. Muat ulang isi dari disk?";
-"Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan file yang ada ?";
+"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari disk?";
+"Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan berkas yang eksis ?";
 
 "Rename to \"{0}\" ?" = "Ubah nama ke \"{0}\" ?";
 "Failed to rename from \"{0}\" to \"{1}\"" = "Gagal mengubah nama dari \"{0}\" ke \"{1}\"";
 
 /* Image upload & move */
 "Successfully uploaded {0} images." = "Berhasil mengunggah {0} gambar.";
-"Failed to upload image. Error Message:" = "Gagal mengunggah gambar. Pesan Kesalahan:";
+"Failed to upload image. Error Message:" = "Gagal mengunggah gambar. Pesan Eror:";
 "Failed to Copy Image to Target Folder." = "Gagal Menyalin Gambar ke Folder Tujuan.";
-"Select Container Folder" = "Pilih Folder Penampung";
+"Select Container Folder" = "Seleksi Kontainer Folder"; /* See <https://kbbi.kemdikbud.go.id/entri/kontainer> */
 
 "Saved" = "Tersimpan";
 
@@ -135,39 +148,39 @@
 "Case Sensitive" = "Peka Huruf Besar/Kecil";
 "Whole Word" = "Seluruh Kata";
 
-"input image URL" = "masukkan URL gambar";
-"Select image from local file" = "Pilih gambar dari file lokal";
-"Cannot open location <code>$1</code>, do you mean <a href='https://$3'>https://$2</a> ?" = "Tidak dapat membuka lokasi <code>$1</code>, apakah maksud Anda <a href='https://$3'>https://$2</a> ?";
+"input image URL" = "input URL gambar";
+"Select image from local file" = "Seleksi gambar dari berkas lokal";
+"Cannot open location <code>$1</code>, do you mean <a href='https://$3'>https://$2</a> ?" = "Takdapat membuka lokasi <code>$1</code>, apakah maksud Anda <a href='https://$3'>https://$2</a> ?";
 
-"select a language" = "pilih bahasa";
-"Finish Editing" = "Akhiri Pengubahan";
+"select a language" = "seleksi bahasa";
+"Finish Editing" = "Selesaikan Penyuntingan";
 
-"Revert advanced setting file to default one ?" = "Kembalikan file pengaturan lanjutan ke versi standar ?";
+"Revert advanced setting file to default one ?" = "Kembalikan setelan lanjutan berkas ke asali ?";
 
-"Select Spell Check Language" = "Pilih Bahasa Pemeriksaan Ejaan";
-"Auto Detect Language" = "Deteksi Bahasa secara Otomatis";
-"Disable Spell Check" = "Matikan Pemeriksaan Ejaan";
+"Select Spell Check Language" = "Seleksi Cek Ejaan Bahasa";
+"Auto Detect Language" = "Oto Deteksi Bahasa"; /* `auto` as `oto`; `automatize` as `otomatis` */
+"Disable Spell Check" = "Nonaktifkan Cek Ejaan";
 "Global Setting…" = "Pengaturan Global…";
-"Dictionary file is missing to enable spellcheck support for %@." = "File kamus untuk mendukung pemeriksaan ejaan untuk %@ tidak tersedia.";
-"Install Language Support" = "Pasang Dukungan Bahasa";
+"Dictionary file is missing to enable spellcheck support for %@." = "Berkas kamus tak tersedia untuk mengaktifkan cek ejaan untuk %@.";
+"Install Language Support" = "Instal Dukungan Bahasa"; /* See <https://kbbi.kemdikbud.go.id/entri/instalasi> */
 "License Information" = "Informasi Lisensi";
 "Download" = "Unduh";
-"Install dictionary file only for Typora" = "Pasang file kamus hanya untuk Typora";
-"Spell Check (%@ unavailable)" = "Pemeriksaan Ejaan (%@ tidak tersedia)";
-"Spell Check (%@ downloading)" = "Pemeriksaan Ejaan (%@ sedang diunduh)";
-"Download dictionary file for %@" = "Unduh file kamus untuk %@";
-"(Default spell check option)" = "(Opsi standar pemeriksaan ejaan)";
-"Failed to load spellcheck module" = "Gagal memuat modul pemeriksaan ejaan";
+"Install dictionary file only for Typora" = "Instal berkas kamus hanya untuk Typora";
+"Spell Check (%@ unavailable)" = "Cek Ejaan (%@ taktersedia)";
+"Spell Check (%@ downloading)" = "Cek Ejaan (%@ sedang diunduh)";
+"Download dictionary file for %@" = "Unduh berkas kamus untuk %@";
+"(Default spell check option)" = "(Opsi asali cek ejaan)";
+"Failed to load spellcheck module" = "Gagal memuat modul cek ejaan";
 
 "<strong>%@</strong> has been turned on." = "<strong>%@</strong> telah diaktifkan.";
-"You could turn it off from `View` menu." = "Anda dapat menonaktifkannya dari menu `Tinjauan`.";
-"The file is too large to render in Typora." = "File terlalu besar untuk di-render di Typora.";
+"You could turn it off from `View` menu." = "Anda dapat menonaktifkannya dari menu `Tampilan`.";
+"The file is too large to render in Typora." = "Berkas terlalu besar untuk dirender di Typora.";
 "Open in…" = "Buka di…";
-"Quick Look" = "Lihat Sekilas";
+"Quick Look" = "Lihat Segera";
 
 "Filter" = "Filter";
-"No result found." = "Tidak ada hasil yang ditemukan.";
+"No result found." = "Tiada hasil yang ditemukan.";
 "Continue & Overwrite" = "Lanjut & Timpa";
-"The file is read-only, or you do not have right permissions to modify the file." = "File dibatasi hanya untuk dilihat, atau Anda tidak punya izin yang sesuai untuk mengubah file tersebut.";
+"The file is read-only, or you do not have right permissions to modify the file." = "Berkas tersedia baca-saja, atau Anda tidak punya izin untuk mengubah berkas tersebut.";
 
 "Learn Data Recovery" = "Pelajari Pemulihan Data";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -45,7 +45,7 @@
 "search text" = "pencarian teks";
 
 /* Quick Open */
-"Search by file name" = "Cari berdasarkan nama berkas";
+"Search by file name" = "Cari berdasarkan nama fail"; /* `Fail` is more accurate than `berkas`, see <https://kbbi.kemdikbud.go.id/entri/fail> */
 "Searching" = "Sedang mencari";
 "Gathering more results" = "Mengumpulkan lebih banyak hasil";
 
@@ -64,27 +64,27 @@
 "Create Folder" = "Buat Folder";
 
 /* Math */
-"Edit" = "Sunting";
+"Edit" = "Edit"; /* `Edit` is more accurate than `sunting`, see <https://kbbi.kemdikbud.go.id/entri/edit> */
 "Delete Math" = "Hapus Matematika";
 "Preview" = "Pratinjau";
 
 /* Sidebar */
 "Articles" = "Artikel";
 "Outline" = "Ikhtisar"; /* See <http://tesaurus.kemdikbud.go.id/tematis/lema/ikhtisar> */
-"Files" = "Berkas";
-"Switch to File List view" = "Alihkan ke tampilan Daftar Berkas";
-"Switch to File Tree view" = "Alihkan ke tampilan Pohon Berkas";
+"Files" = "Fail";
+"Switch to File List view" = "Alihkan ke tampilan Daftar Fail";
+"Switch to File Tree view" = "Alihkan ke tampilan Pohon Fail";
 "Switch to Outline view" = "Alihkan ke tampilan Ikhtisar";
 "Close sidebar" = "Tutup bilahsisi";
 "Loading" = "Memuat";
-"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak berkas. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tampilan Pohon Berkas</a> untuk kinerja yang lebih baik.";
-"New File" = "Berkas Baru";
+"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak fail. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tampilan Pohon Fail</a> untuk kinerja yang lebih baik.";
+"New File" = "Fail Baru";
 "Unpin Outline Panel" = "Takpinkan Panel Ikhtisar";
 "Open Folder..." = "Buka Folder...";
 "Action" = "Aksi";
 "Close Sidebar Menu" = "Tutup Menu Bilahsisi";
 "Reveal in Finder" = "Tampilkan di Finder";
-"Reveal in File Explorer" = "Tampilkan di Eksplorasi Berkas";
+"Reveal in File Explorer" = "Tampilkan di Eksplorasi Fail";
 "Refresh Folder" = "Kembalisegarkan Folder";
 "Sort" = "Sortir";
 "Group By Folder" = "Grup Berdasarkan Folder";
@@ -95,8 +95,8 @@
 "Sort by Modification Date (Descending)" = "Sortir berdasarkan modifikasi Tanggal (Turun)";
 "Recent Locations" = "Lokasi Terkini";
 "Location" = "Lokasi";
-"Switch File List/Tree View" = "Alihkan Tampilan Daftar/Pohon Berkas";
-"No Files Available" = "Tiada Berkas yang Tersedia";
+"Switch File List/Tree View" = "Alihkan Tampilan Daftar/Pohon Fail";
+"No Files Available" = "Tiada Fail yang Tersedia";
 "No Folder is Opened." = "Tiada Folder yang Terbuka.";
 "Outline is Empty." = "Ikhtisar Kosong.";
 
@@ -114,21 +114,21 @@
 "Please define image reference by \n[{0}]: http://example.png" = "Sila definisikan referensi gambar dengan \n[{0}]: http://example.png"; /* `Link` as `pranala`, see <https://kbbi.kemdikbud.go.id/entri/pranala> */
 
 /* msg */
-"Failed to create file" = "Gagal membuat berkas";
+"Failed to create file" = "Gagal membuat fail";
 "Failed to create folder" = "Gagal membuat folder";
-"Failed to rename file" = "Gagal ubah nama berkas";
+"Failed to rename file" = "Gagal ubah nama fail";
 "Folder does not exist at %@" = "Folder tidak eksis di %@";
-"File with the same name already exists at target path" = "Berkas dengan nama yang sama telah ada di target jalur";
+"File with the same name already exists at target path" = "Fail dengan nama yang sama telah ada di target jalur";
 "Apply to All" = "Terapkan untuk Semua";
 "Overwrite" = "Timpa";
 "Stop" = "Stop"; /* See <https://kbbi.kemdikbud.go.id/entri/stop> */
 "back to document" = "kembali ke dokumen";
-"Failed to load file" = "Gagal memuat berkas";
-"Save File Failed!" = "Simpan Berkas Gagal!";
+"Failed to load file" = "Gagal memuat fail";
+"Save File Failed!" = "Simpan Fail Gagal!";
 "Cannot open folder {0}" = "Takdapat membuka folder {0}";
 
-"File content is changed by external applications. Reload content from disk ?" = "Konten berkas diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> or <http://tesaurus.kemdikbud.go.id/tematis/lema/diska> */
-"Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan berkas yang eksis ?";
+"File content is changed by external applications. Reload content from disk ?" = "Konten fail diganti oleh aplikasi eksternal. Muatulang konten dari diska?"; /* See <https://kbbi.kemdikbud.go.id/entri/diska> or <http://tesaurus.kemdikbud.go.id/tematis/lema/diska> */
+"Should continue moving and overwrite exisiting file(s) ?" = "Lanjutkan pemindahan dan penimpaan fail yang eksis ?";
 
 "Rename to \"{0}\" ?" = "Ubah nama ke \"{0}\" ?";
 "Failed to rename from \"{0}\" to \"{1}\"" = "Gagal mengubah nama dari \"{0}\" ke \"{1}\"";
@@ -149,38 +149,38 @@
 "Whole Word" = "Seluruh Kata";
 
 "input image URL" = "input URL gambar";
-"Select image from local file" = "Seleksi gambar dari berkas lokal";
+"Select image from local file" = "Seleksi gambar dari fail lokal";
 "Cannot open location <code>$1</code>, do you mean <a href='https://$3'>https://$2</a> ?" = "Takdapat membuka lokasi <code>$1</code>, apakah maksud Anda <a href='https://$3'>https://$2</a> ?";
 
 "select a language" = "seleksi bahasa";
-"Finish Editing" = "Selesaikan Penyuntingan";
+"Finish Editing" = "Selesaikan Pengeditan"; /* `Pengeditan` is more accurate than `penyuntingan`, see <https://kbbi.kemdikbud.go.id/entri/pengeditan> */
 
-"Revert advanced setting file to default one ?" = "Kembalikan setelan lanjutan berkas ke asali ?";
+"Revert advanced setting file to default one ?" = "Kembalikan setelan lanjutan fail ke asali ?";
 
 "Select Spell Check Language" = "Seleksi Cek Ejaan Bahasa";
 "Auto Detect Language" = "Oto Deteksi Bahasa"; /* `auto` as `oto`; `automatize` as `otomatis` */
 "Disable Spell Check" = "Nonaktifkan Cek Ejaan";
 "Global Setting…" = "Pengaturan Global…";
-"Dictionary file is missing to enable spellcheck support for %@." = "Berkas kamus tak tersedia untuk mengaktifkan cek ejaan untuk %@.";
+"Dictionary file is missing to enable spellcheck support for %@." = "Fail kamus tak tersedia untuk mengaktifkan cek ejaan untuk %@.";
 "Install Language Support" = "Instal Dukungan Bahasa"; /* See <https://kbbi.kemdikbud.go.id/entri/instalasi> */
 "License Information" = "Informasi Lisensi";
 "Download" = "Unduh";
-"Install dictionary file only for Typora" = "Instal berkas kamus hanya untuk Typora";
+"Install dictionary file only for Typora" = "Instal fail kamus hanya untuk Typora";
 "Spell Check (%@ unavailable)" = "Cek Ejaan (%@ taktersedia)";
 "Spell Check (%@ downloading)" = "Cek Ejaan (%@ sedang diunduh)";
-"Download dictionary file for %@" = "Unduh berkas kamus untuk %@";
+"Download dictionary file for %@" = "Unduh fail kamus untuk %@";
 "(Default spell check option)" = "(Opsi asali cek ejaan)";
 "Failed to load spellcheck module" = "Gagal memuat modul cek ejaan";
 
 "<strong>%@</strong> has been turned on." = "<strong>%@</strong> telah diaktifkan.";
 "You could turn it off from `View` menu." = "Anda dapat menonaktifkannya dari menu `Tampilan`.";
-"The file is too large to render in Typora." = "Berkas terlalu besar untuk dirender di Typora.";
+"The file is too large to render in Typora." = "Fail terlalu besar untuk dirender di Typora.";
 "Open in…" = "Buka di…";
 "Quick Look" = "Lihat Segera";
 
 "Filter" = "Filter";
 "No result found." = "Tiada hasil yang ditemukan.";
 "Continue & Overwrite" = "Lanjut & Timpa";
-"The file is read-only, or you do not have right permissions to modify the file." = "Berkas tersedia baca-saja, atau Anda tidak punya izin untuk mengubah berkas tersebut.";
+"The file is read-only, or you do not have right permissions to modify the file." = "Fail tersedia baca-saja, atau Anda tidak punya izin untuk mengubah fail tersebut.";
 
 "Learn Data Recovery" = "Pelajari Pemulihan Data";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -66,18 +66,18 @@
 /* Math */
 "Edit" = "Edit"; /* `Edit` is more accurate than `sunting`, see <https://kbbi.kemdikbud.go.id/entri/edit> */
 "Delete Math" = "Hapus Matematika";
-"Preview" = "Pratinjau";
+"Preview" = "Pratinjau"; /* So `view` is `tinjau`, see <https://kbbi.kemdikbud.go.id/entri/tinjau> */
 
 /* Sidebar */
 "Articles" = "Artikel";
 "Outline" = "Ikhtisar"; /* See <http://tesaurus.kemdikbud.go.id/tematis/lema/ikhtisar> */
 "Files" = "Fail";
-"Switch to File List view" = "Alihkan ke tampilan Daftar Fail";
-"Switch to File Tree view" = "Alihkan ke tampilan Pohon Fail";
-"Switch to Outline view" = "Alihkan ke tampilan Ikhtisar";
+"Switch to File List view" = "Alihkan ke tinjauan Daftar Fail";
+"Switch to File Tree view" = "Alihkan ke tinjauan Pohon Fail";
+"Switch to Outline view" = "Alihkan ke tinjauan Ikhtisar";
 "Close sidebar" = "Tutup bilahsisi";
 "Loading" = "Memuat";
-"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak fail. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tampilan Pohon Fail</a> untuk kinerja yang lebih baik.";
+"Selected folders contains too many files. \nPlease switch to <a id='switch-to-tree-on-oversize'>File Tree view</a> for better performance." = "Folder yang dipilih mengandung terlalu banyak fail. \nMohon ubah ke <a id='switch-to-tree-on-oversize'>tinjauan Pohon Fail</a> untuk kinerja yang lebih baik.";
 "New File" = "Fail Baru";
 "Unpin Outline Panel" = "Takpinkan Panel Ikhtisar";
 "Open Folder..." = "Buka Folder...";
@@ -95,7 +95,7 @@
 "Sort by Modification Date (Descending)" = "Sortir berdasarkan modifikasi Tanggal (Turun)";
 "Recent Locations" = "Lokasi Terkini";
 "Location" = "Lokasi";
-"Switch File List/Tree View" = "Alihkan Tampilan Daftar/Pohon Fail";
+"Switch File List/Tree View" = "Alihkan Tinjauan Daftar/Pohon Fail";
 "No Files Available" = "Tiada Fail yang Tersedia";
 "No Folder is Opened." = "Tiada Folder yang Terbuka.";
 "Outline is Empty." = "Ikhtisar Kosong.";
@@ -173,7 +173,7 @@
 "Failed to load spellcheck module" = "Gagal memuat modul cek ejaan";
 
 "<strong>%@</strong> has been turned on." = "<strong>%@</strong> telah diaktifkan.";
-"You could turn it off from `View` menu." = "Anda dapat menonaktifkannya dari menu `Tampilan`.";
+"You could turn it off from `View` menu." = "Anda dapat menonaktifkannya dari menu `Tinjau`.";
 "The file is too large to render in Typora." = "Fail terlalu besar untuk dirender di Typora.";
 "Open in…" = "Buka di…";
 "Quick Look" = "Lihat Segera";

--- a/id-ID.lproj/Front.strings
+++ b/id-ID.lproj/Front.strings
@@ -18,7 +18,7 @@
 
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
-  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
 
 */
 

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -4,83 +4,95 @@
 
  by hi@typora.io
 
- Indonesian (Bahasa Indonesia) translation
- by Samuel Natalius (@snatalius)
- samnatalius[at]outlook[dot]com
+ Indonesian (Bahasa Indonesia) Translation
+ by Samuel Natalius <https://github.com/snatalius> <samnatalius@outlook.com>,
+    Kylamber <https://github.com/Kylamber> <>,
+    Nashrullah Ali Fauzi <https://github.com/nashrullahalifauzi> <nash@nashrullahalifauzi.com>.
+
+  Notice:
+
+  If there is an loanword in the Indonesian dictionary, then use it in Typora. For example, if in English there is the word `font`, then in standard Indonesian it should be written `fon` without the letter `t`, even though there is a non-standard word, `fonta` which has the same meaning.
+
+  Likewise with the word 'input' in English, when it is translated into Indonesian it does not change, because the word 'input' in the Indonesian dictionary, also has the same meaning in English. It is not appropriate to translate the English word 'input' as 'masukan' in Indonesian. This is an attempt to keep the language of the app, especially Typora, from straying too far from its native language as default.
+
+  `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
+
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+
 */
 
 /* Typora Menu */
 
 "About Typora" = "Tentang Typora";
 "Preferences" = "Preferensi";
-"Check for Updates" = "Periksa Pembaruan";
-"Services" = "Layanan";
+"Check for Updates" = "Cek Pemutakhiran"; /* All the words `check` should be more than enough with just `cek` in Indonesian */
+"Services" = "Servis"; /* See <https://kbbi.kemdikbud.go.id/entri/servis> */
 "Hide Typora" = "Sembunyikan Typora";
 "Hide Others" = "Sembunyikan Lainnya";
 "Show All" = "Tampilkan Semua";
-"Quit Typora" = "Keluar dari Typora";
+"Quit Typora" = "Keluarkan Typora";
 
 /* File Menu */
 
-"File" = "File";
+"File" = "Berkas";
 "New" = "Baru";
 "Open" = "Buka";
 "Open Folder" = "Buka Folder";
-"Reopen with Encoding" = "Buka Kembali dengan Pengodean";
-"Auto" = "Otomatis";
-"Open Recent" = "Buka File Terkini";
+"Reopen with Encoding" = "Buka Kembali dengan Pengkodean"; /* Standard word is `pengkodean`, not `pengodean`. See <https://kbbi.kemdikbud.go.id/entri/pengkodean> */
+"Auto" = "Oto";
+"Open Recent" = "Buka (Berkas) Terkini"; /* `berkas` is an insert, it's better to put brackets */
 "Recent Locations" = "Lokasi Terkini";
-"Clear Items" = "Hilangkan Item";
-"No Recent Files" = "Tidak Ada File Terkini";
-"Open Quickly" = "Buka Dengan Cepat";
-"Open File Location" = "Buka Lokasi File";
-"Reveal in Library" = "Ungkap dalam Pustaka";
-"Reveal in File Tree" = "Ungkap dalam Pohon File";
+"Clear Items" = "Bersihkan Item";
+"No Recent Files" = "Tiada Berkas Terkini";
+"Open Quickly" = "Buka Segera"; /* all `quick` or `quickly` as `segera`, for context see <https://kbbi.kemdikbud.go.id/entri/segera> */
+"Open File Location" = "Buka Lokasi Berkas";
+"Reveal in Library" = "Ungkapkan dalam Pustaka";
+"Reveal in File Tree" = "Ungkapkan dalam Pohon Berkas";
 "Close" = "Tutup";
 "Save" = "Simpan";
-"Save As" = "Simpan sebagai";
-"Duplicate" = "Gandakan";
+"Save As" = "Simpan sebagai"; /* `as` or `sebagai` is conjunction, so in Indonesian must start with a lowercase letter */
+"Duplicate" = "Duplikasikan"; /* See <https://kbbi.kemdikbud.go.id/entri/duplikasi>, `kan` is an affix for imperative verbs in Indonesian. */
 "Rename" = "Ubah Nama";
 "Move To" = "Pindahkan ke";
-"Revert To" = "Kembalikan kepada";
+"Revert To" = "Kembalikan ke";
 "Browse All Versions" = "Telusuri Semua Versi";
 "Import" = "Impor";
 "Export" = "Ekspor";
-"Page Setup" = "Penyetelan Halaman";
+"Page Setup" = "Setel Halaman";
 "Print" = "Cetak";
 
 /* Edit Menu */
-"Edit" = "Edit";
-"Undo" = "Kembalikan";
+"Edit" = "Sunting";
+"Undo" = "Takjadi";
 "Redo" = "Ulangi";
 "Cut" = "Potong";
-"Copy" = "Salin";
+"Copy" = "Kopi"; /* See <https://kbbi.kemdikbud.go.id/entri/kopi> which also means `salin` */
 "Paste" = "Tempel";
-"Copy as Markdown" = "Salin sebagai Markdown";
-"Copy as HTML Code" = "Salin sebagai Kode HTML";
+"Copy as Markdown" = "Kopi sebagai Markdown";
+"Copy as HTML Code" = "Kopi sebagai Kode HTML";
 "Paste as Plain Text" = "Tempel sebagai Teks Biasa";
-"Select All" = "Pilih Semua";
-"Select Line/Sentence" = "Pilih Baris/Kalimat";
-"Select Styled Scope" = "Pilih Lingkup Gaya";
-"Select Word" = "Pilih Kata";
+"Select All" = "Seleksi Semua";
+"Select Line/Sentence" = "Seleksi Baris/Kalimat";
+"Select Styled Scope" = "Seleksi Skop Gaya"; /* See <https://kbbi.kemdikbud.go.id/entri/skop> */
+"Select Word" = "Seleksi Kata";
 "Delete" = "Hapus";
-"Delete Range" = "Hapus dalam Rentang";
+"Delete Range" = "Hapus Rentang";
 "Delete Word" = "Hapus Kata";
-"Delete Styled Scope" = "Hapus Lingkup Gaya";
+"Delete Styled Scope" = "Hapus Skop Gaya";
 "Delete Line/Sentence" = "Hapus Baris/Kalimat";
 "Jump To" = "Lompat ke";
 "Jump to Top" = "Lompat ke Atas";
-"Jump to Selection" = "Lompat ke Pilihan";
+"Jump to Selection" = "Lompat ke Seleksi";
 "Jump to Bottom" = "Lompat ke Bawah";
 "Math Tools" = "Alat Matematika";
-"Refresh All Math Expressions" = "Muat Ulang Semua Ekspresi Matematika";
+"Refresh All Math Expressions" = "Segarkan Semua Ekspresi Matematika"; /* all `refresh` as `segarkan` */
 "Image Tools" = "Alat Gambar";
 "Insert Local Images" = "Sisipkan Gambar Lokal";
-"Upload Local Images via iPic" = "Unggah Gambar Lokal lewat iPic";
+"Upload Local Images via iPic" = "Unggah Gambar Lokal via iPic"; /* `via` must stay the same */
 "When Insert Local Image" = "Ketika Menyisipkan Gambar Lokal";
-"Copy Image File to Folder" = "Salin File Gambar ke Folder";
-"Upload Image via iPic" = "Unggah Gambar lewat iPic";
-"Use Image Root Path" = "Gunakan Path Asal Gambar";
+"Copy Image File to Folder" = "Kopi Berkas Gambar ke Folder";
+"Upload Image via iPic" = "Unggah Gambar via iPic";
+"Use Image Root Path" = "Gunakan Jalur Akar Gambar";
 "Line Endings" = "Akhiran Baris";
 "Windows Line Endings (CRLF)" = "Akhiran Baris Windows (CRLF)";
 "Unix Line Endings (LF)" = "Akhiran Baris Unix (LF)";
@@ -91,10 +103,10 @@
 "Replace" = "Ganti";
 "Replace Next" = "Temukan Berikutnya";
 "Spelling and Grammar" = "Ejaan dan Tata Bahasa";
-"Check Document Now" = "Periksa Dokumen Sekarang";
-"Check Spelling While Typing" = "Periksa Ejaan ketika Mengetik";
-"Check Grammar With Spelling" = "Periksa Tata Bahasa dengan Ejaan";
-"Correct Spelling Automatically" = "Perbaiki Ejaan secara Otomatis";
+"Check Document Now" = "Cek Dokumen Sekarang";
+"Check Spelling While Typing" = "Cek Ejaan ketika Mengetik";
+"Check Grammar With Spelling" = "Cek Tata Bahasa dengan Ejaan";
+"Correct Spelling Automatically" = "Koreksi Ejaan secara Otomatis"; /* See <https://kbbi.kemdikbud.go.id/entri/koreksi> */
 "Substitutions" = "Substitusi";
 "Smart Quotes" = "Kutipan Cerdas";
 "Smart Dashes" = "Tanda Hubung Cerdas";
@@ -105,31 +117,31 @@
 
 /* Paragraph Menu */
 "Paragraph" = "Paragraf";
-"Heading 1" = "Heading 1";
-"Heading 2" = "Heading 2";
-"Heading 3" = "Heading 3";
-"Heading 4" = "Heading 4";
-"Heading 5" = "Heading 5";
-"Heading 6" = "Heading 6";
-"Increase Heading Level" = "Naikkan Tingkatan Heading";
-"Decrease Heading Level" = "Turunkan Tingkatan Heading";
+"Heading 1" = "Tajuk 1"; /* See <https://kbbi.kemdikbud.go.id/entri/tajuk> */
+"Heading 2" = "Tajuk 2";
+"Heading 3" = "Tajuk 3";
+"Heading 4" = "Tajuk 4";
+"Heading 5" = "Tajuk 5";
+"Heading 6" = "Tajuk 6";
+"Increase Heading Level" = "Naikkan Level Tajuk"; /* See <https://kbbi.kemdikbud.go.id/entri/level> */
+"Decrease Heading Level" = "Turunkan Level Tajuk";
 "Table" = "Tabel";
-"Code Fences" = "Kotak Kode";
+"Code Fences" = "Pagar Kode";
 "Math Block" = "Blok Matematika";
 "Quote" = "Kutipan";
-"Ordered List" = "Daftar Terurut";
-"Unordered List" = "Daftar Tidak Terurut";
+"Ordered List" = "Lis Berurut"; /* See <https://kbbi.kemdikbud.go.id/entri/lis> */
+"Unordered List" = "Lis Takberurut";
 "Task List" = "Daftar Tugas";
 "Task Status" = "Status Tugas";
 "Toggle Task Status" = "Ganti Status Tugas";
-"Mark as Complete" = "Tandai sebagai Selesai";
-"Mark as Incomplete" = "Tandai sebagai Tidak Selesai";
-"List Indentation" = "Penganjuran Daftar";
-"Indent" = "Anjurkan ke Dalam";
-"Outdent" = "Anjurkan ke Luar";
-"Link Reference" = "Referensi Tautan";
+"Mark as Complete" = "Tandai sebagai Komplet"; /* See <https://kbbi.kemdikbud.go.id/entri/komplet> */
+"Mark as Incomplete" = "Tandai sebagai Takkomplet";
+"List Indentation" = "Lis Indentasi";
+"Indent" = "Indentasi";
+"Outdent" = "Outdentasi";
+"Link Reference" = "Referensi Pranala";
 "Footnotes" = "Catatan Kaki";
-"Horizontal Line" = "Garis Mendatar";
+"Horizontal Line" = "Garis Horizontal";
 "Table of Contents" = "Daftar Isi";
 "YAML Front Matter" = "YAML Front Matter";
 
@@ -137,36 +149,36 @@
 "Format" = "Format";
 "Strong" = "Tebal";
 "Emphasis" = "Miring";
-"Underline" = "Garis Bawah";
+"Underline" = "Garisbawah";
 "Code" = "Kode";
 "Inline Math" = "Matematika Sebaris";
 "Strike" = "Coret";
 "Highlight" = "Sorotan";
-"Superscript" = "Tika Atas";
-"Subscript" = "Tika Bawah";
+"Superscript" = "Superskrip";
+"Subscript" = "Subskrip";
 "Comment" = "Komentar";
-"Hyperlink" = "Hyperlink";
+"Hyperlink" = "Hipertaut"; /* See <https://kbbi.kemdikbud.go.id/entri/hipertaut> */
 "Image" = "Gambar";
-"Clear Format" = "Hilangkan Format";
+"Clear Format" = "Bersihkan Format";
 
 /* View Menu */
-"View" = "Lihat";
-"New Tab" = "Tab Baru";
+"View" = "Tampilan";
+"New Tab" = "Bilah Baru";
 "Source Code Mode" = "Mode Kode Sumber";
 "Focus Mode" = "Mode Fokus";
 "Typewriter Mode" = "Mode Mesin Tik";
-"Toggle Sidebar" = "(Non-)aktifkan Bilah Sisi";
+"Toggle Sidebar" = "(Non-)aktifkan Bilahsisi";
 "Outline" = "Ikhtisar";
 "Articles" = "Artikel";
-"File Tree" = "Pohon File";
+"File Tree" = "Pohon Berkas";
 "Always on Top" = "Selalu di Atas";
 "Full Screen" = "Layar Penuh";
-"Show Status Bar" = "Tampilkan Bilah Status";
+"Show Status Bar" = "Munculkan Bilah Status"; /* to differentiate `show` (muncul) and `view` (tampil) */
 "Toggle Fullscreen" = "(Non-)aktifkan Layar Penuh";
-"Actual Size" = "Ukuran Sebenarnya";
-"Zoom In" = "Perbesar Tampilan";
-"Zoom Out" = "Perkecil Tampilan";
-"Switch Between Opened Documents" = "Pindah ke Dokumen Aktif Lainnya";
+"Actual Size" = "Ukuran Aktual";
+"Zoom In" = "Zum (ke) Dalam";
+"Zoom Out" = "Zum (ke) Luar";
+"Switch Between Opened Documents" = "Beralih Antara Dokumen yang Dibuka";
 "Toggle DevTools" = "(Non-)aktifkan DevTools";
 
 
@@ -175,58 +187,58 @@
 
 /* Window Menu */
 "Window" = "Jendela";
-"Minimize" = "Kecilkan";
-"Zoom" = "Perbesar";
-"Bring All to Front" = "Majukan Semua ke Depan";
+"Minimize" = "Minimalkan"; /* See <https://kbbi.kemdikbud.go.id/entri/minimal> */
+"Zoom" = "Zum"; /* See <https://kbbi.kemdikbud.go.id/entri/zum> */
+"Bring All to Front" = "Bawa Semua ke Front"; /* See <https://kbbi.kemdikbud.go.id/entri/front> */
 
 /* Help Menu */
 "Help" = "Bantuan";
-"Privacy Policy" = "Aturan Privasi";
+"Privacy Policy" = "Kebijakan Privasi";
 "Credits" = "Kredit";
 "Change Log" = "Log Perubahan";
-"Website" = "Situs Jejaring";
-"Feedback" = "Umpan Balik";
+"Website" = "Situsweb";
+"Feedback" = "Umpanbalik";
 "About" = "Tentang";
 
 /* Touchbar */
 "Block Styles" = "Gaya Blok";
 "Inline Styles" = "Gaya dalam Baris";
-"List Styles / Remove Block" = "List Styles / Remove Block";
-"Exit Source Code Mode" = "Keluar dari Mode Source Code";
-"Toggle Source Code Mode" = "(Non-)aktifkan Mode Source Code";
+"List Styles / Remove Block" = "Gaya Lis / Hapus Blok";
+"Exit Source Code Mode" = "Keluarkan Mode Kode Sumber";
+"Toggle Source Code Mode" = "(Non-)aktifkan Mode Kode Sumber";
 
 /* Extra Context Menu */
 "Table" = "Tabel";
-"Add Row Above" = "Tambah Baris di Atas";
-"Add Row Below" = "Tambah Baris di Bawah";
+"Add Row Above" = "Tambah Baris Atas";
+"Add Row Below" = "Tambah Baris Bawah";
 "Delete Row" = "Hapus Baris";
 "Add Column Before" = "Tambah Kolom Sebelum";
 "Add Column After" = "Tambah Kolom Sesudah";
 "Delete Column" = "Hapus Kolom";
-"Copy Table" = "Salin Tabel";
+"Copy Table" = "Kopi Tabel";
 "Delete Table" = "Hapus Tabel";
 "Insert Paragraph After" = "Sisipkan Paragram Setelah";
 "Insert Paragraph Before" = "Sisipkan Paragram Sebelum";
 "Delete Code Block" = "Hapus Blok Kode";
-"Copy as MathML" = "Salin sebagai MathML";
-"Copy as Tex" = "Salin sebagai Tex";
-"Copy Math" = "Salin Matematika";
+"Copy as MathML" = "Kopi sebagai MathML";
+"Copy as Tex" = "Kopi sebagai Tex";
+"Copy Math" = "Kopi Matematika";
 "Reveal in Finder" = "Tampilkan di Finder";
-"Open Link" = "Buka Tautan";
-"Reveal in Sidebar" = "Tampilkan di Bilah Sisi";
+"Open Link" = "Buka Pranala";
+"Reveal in Sidebar" = "Tampilkan di Bilahsisi";
 "Open in New Window" = "Buka di Jendela Baru";
-"Copy File Path" = "Salin Path File";
-"New File" = "File Baru";
+"Copy File Path" = "Kopi Jalur Berkas";
+"New File" = "Berkas Baru";
 "Rename" = "Ubah Nama";
 "New Folder" = "Folder Baru";
 
 /* Electron */
 "Learn Spelling" = "Pelajari Ejaan";
-"Copy / Paste As…" = "Salin / Tempel sebagai…";
+"Copy / Paste As…" = "Kopi / Tempel sebagai…";
 "Math" = "Matematika";
 "Insert" = "Sisipkan";
-"Inspect Element" = "Sisipkan Elemen";
-"Copy to MS Word" = "Salin ke MS Word";
+"Inspect Element" = "Inspeksi Elemen";
+"Copy to MS Word" = "Kopi ke MS Word";
 "Paragraph (before)" = "Paragraf (sebelum)";
 "Paragraph (after)" = "Paragraf (sesudah)";
 
@@ -235,46 +247,46 @@
 
 /* Related Panel */
 "Open Failed" = "Proses Pembukaan Gagal";
-"File or folder does not exist." = "File atau folder tidak ada.";
+"File or folder does not exist." = "Berkas atau folder tidak eksis.";
 
-"Prettify Source Code" = "Percantik Source Code";
-"Copy '%@'" = "Salin '%@'";
-"Copy to %@" = "Salin ke %@";
-"Copy Image to" = "Salin gambar ke";
-"Upload via iPic" = "Unggah melalui iPic";
+"Prettify Source Code" = "Percantik Kode Sumber";
+"Copy '%@'" = "Kopi '%@'";
+"Copy to %@" = "Kopi ke %@";
+"Copy Image to" = "Kopi Gambar ke";
+"Upload via iPic" = "Unggah via iPic";
 "Open Image Location" = "Buka Lokasi Gambar";
 
-"Learn More" = "Pelajari Lebih Lanjut";
-"Whitespace and Line Breaks" = "Spasi Putih dan Pembatas Baris";
-"Indent first line of paragraphs" = "Anjurkan baris paragraf pertama ke dalam";
-"Preserve single line break" = "Pertahankan pembatas garis tunggal";
-"Visible <br/>" = "Terlihat <br/>";
+"Learn More" = "Pelajari Lagi";
+"Whitespace and Line Breaks" = "Spasiputih dan Jeda Baris";
+"Indent first line of paragraphs" = "Indentasi baris pertama paragraf";
+"Preserve single line break" = "Pertahankan jeda baris tunggal";
+"Visible <br/>" = "Visibel <br/>"; /* See <https://kbbi.kemdikbud.go.id/entri/visibel> */
 
 "Save All" = "Simpan Semua";
 "New Window" = "Jendela Baru";
-"Reopen Closed File" = "Buka Kembali File yang Ditutup";
+"Reopen Closed File" = "Kembali Buka Berkas Tertutup";
 
-"Global Image Settings" = "Pengaturan Gambar Global";
-"Smart Punctuation" = "Tanda Baca Cerdas";
-"Convert on Input" = "Konversikan saat Pemasukan";
+"Global Image Settings" = "Setelan Gambar Global";
+"Smart Punctuation" = "Pungtuasi Cerdas"; <https://kbbi.kemdikbud.go.id/entri/pungtuasi> */
+"Convert on Input" = "Konversikan saat Input";
 "Convert on Rendering" = "Konversikan saat Rendering";
-"Remap Unicode Punctuation on Parse" = "Petakan Ulang Tanda Baca Unicode saat Penguraian";
+"Remap Unicode Punctuation on Parse" = "Petaulangkan Pungtuasi Unicode saat Penguraian";
 "More Options" = "Pilihan Lainnya";
 
 "HTML Block" = "Blok HTML";
 "Delete Block" = "Hapus Blok";
 "Delete %@" = "Hapus %@";
-"Play" = "Mainkan";
+"Play" = "Putar";
 "Pause" = "Jeda";
 
-"Spell Check" = "Pemeriksaan Ejaan";
-"Unlearn Spelling" = "Ejaan yang Belum Dipelajari";
+"Spell Check" = "Cek Ejaan";
+"Unlearn Spelling" = "Ejaan Takterpelajari";
 "Properties" = "Properti";
 
 "Search" = "Cari";
-"Copy without Theme Styling" = "Salin tanpa Pengaturan Gaya Tema";
-"Recent Files" = "File Terkini";
-"File Results" = "Hasil File";
+"Copy without Theme Styling" = "Kopi tanpa Gaya Tema";
+"Recent Files" = "Berkas Terkini";
+"File Results" = "Hasil Berkas";
 
 "Insert Table" = "Sisipkan Tabel";
 "Insert Image" = "Sisipkan Gambar";

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -143,7 +143,7 @@
 "Link Reference" = "Referensi Pranala";
 "Footnotes" = "Catatan Kaki";
 "Horizontal Line" = "Garis Horizontal";
-"Table of Contents" = "Daftar Isi";
+"Table of Contents" = "Tabel Konten";
 "YAML Front Matter" = "YAML Front Matter";
 
 /* Format Menu */

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -17,7 +17,7 @@
 
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
-  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
 
 */
 

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -34,20 +34,20 @@
 
 /* File Menu */
 
-"File" = "Berkas";
+"File" = "Fail"; /* `Fail` is more accurate than `berkas`, see <https://kbbi.kemdikbud.go.id/entri/fail> */
 "New" = "Baru";
 "Open" = "Buka";
 "Open Folder" = "Buka Folder";
 "Reopen with Encoding" = "Buka Kembali dengan Pengkodean"; /* Standard word is `pengkodean`, not `pengodean`. See <https://kbbi.kemdikbud.go.id/entri/pengkodean> */
 "Auto" = "Oto";
-"Open Recent" = "Buka (Berkas) Terkini"; /* `berkas` is an insert, it's better to put brackets */
+"Open Recent" = "Buka (Fail) Terkini"; /* `fail` is an insert, it's better to put brackets */
 "Recent Locations" = "Lokasi Terkini";
 "Clear Items" = "Bersihkan Item";
-"No Recent Files" = "Tiada Berkas Terkini";
+"No Recent Files" = "Tiada Fail Terkini";
 "Open Quickly" = "Buka Segera"; /* all `quick` or `quickly` as `segera`, for context see <https://kbbi.kemdikbud.go.id/entri/segera> */
-"Open File Location" = "Buka Lokasi Berkas";
+"Open File Location" = "Buka Lokasi Fail";
 "Reveal in Library" = "Ungkapkan dalam Pustaka";
-"Reveal in File Tree" = "Ungkapkan dalam Pohon Berkas";
+"Reveal in File Tree" = "Ungkapkan dalam Pohon Fail";
 "Close" = "Tutup";
 "Save" = "Simpan";
 "Save As" = "Simpan sebagai"; /* `as` or `sebagai` is conjunction, so in Indonesian must start with a lowercase letter */
@@ -62,7 +62,7 @@
 "Print" = "Cetak";
 
 /* Edit Menu */
-"Edit" = "Sunting";
+"Edit" = "Edit"; /* `Edit` is more accurate than `sunting`, see <https://kbbi.kemdikbud.go.id/entri/edit> */
 "Undo" = "Takjadi";
 "Redo" = "Ulangi";
 "Cut" = "Potong";
@@ -90,7 +90,7 @@
 "Insert Local Images" = "Sisipkan Gambar Lokal";
 "Upload Local Images via iPic" = "Unggah Gambar Lokal via iPic"; /* `via` must stay the same */
 "When Insert Local Image" = "Ketika Menyisipkan Gambar Lokal";
-"Copy Image File to Folder" = "Kopi Berkas Gambar ke Folder";
+"Copy Image File to Folder" = "Kopi Fail Gambar ke Folder";
 "Upload Image via iPic" = "Unggah Gambar via iPic";
 "Use Image Root Path" = "Gunakan Jalur Akar Gambar";
 "Line Endings" = "Akhiran Baris";
@@ -170,7 +170,7 @@
 "Toggle Sidebar" = "(Non-)aktifkan Bilahsisi";
 "Outline" = "Ikhtisar";
 "Articles" = "Artikel";
-"File Tree" = "Pohon Berkas";
+"File Tree" = "Pohon Fail";
 "Always on Top" = "Selalu di Atas";
 "Full Screen" = "Layar Penuh";
 "Show Status Bar" = "Munculkan Bilah Status"; /* to differentiate `show` (muncul) and `view` (tampil) */
@@ -227,8 +227,8 @@
 "Open Link" = "Buka Pranala";
 "Reveal in Sidebar" = "Tampilkan di Bilahsisi";
 "Open in New Window" = "Buka di Jendela Baru";
-"Copy File Path" = "Kopi Jalur Berkas";
-"New File" = "Berkas Baru";
+"Copy File Path" = "Kopi Jalur Fail";
+"New File" = "Fail Baru";
 "Rename" = "Ubah Nama";
 "New Folder" = "Folder Baru";
 
@@ -247,7 +247,7 @@
 
 /* Related Panel */
 "Open Failed" = "Proses Pembukaan Gagal";
-"File or folder does not exist." = "Berkas atau folder tidak eksis.";
+"File or folder does not exist." = "Fail atau folder tidak eksis.";
 
 "Prettify Source Code" = "Percantik Kode Sumber";
 "Copy '%@'" = "Kopi '%@'";
@@ -264,7 +264,7 @@
 
 "Save All" = "Simpan Semua";
 "New Window" = "Jendela Baru";
-"Reopen Closed File" = "Kembali Buka Berkas Tertutup";
+"Reopen Closed File" = "Kembali Buka Fail Tertutup";
 
 "Global Image Settings" = "Setelan Gambar Global";
 "Smart Punctuation" = "Pungtuasi Cerdas"; <https://kbbi.kemdikbud.go.id/entri/pungtuasi> */
@@ -285,8 +285,8 @@
 
 "Search" = "Cari";
 "Copy without Theme Styling" = "Kopi tanpa Gaya Tema";
-"Recent Files" = "Berkas Terkini";
-"File Results" = "Hasil Berkas";
+"Recent Files" = "Fail Terkini";
+"File Results" = "Hasil Fail";
 
 "Insert Table" = "Sisipkan Tabel";
 "Insert Image" = "Sisipkan Gambar";

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -30,7 +30,7 @@
 "Services" = "Servis"; /* See <https://kbbi.kemdikbud.go.id/entri/servis> */
 "Hide Typora" = "Sembunyikan Typora";
 "Hide Others" = "Sembunyikan Lainnya";
-"Show All" = "Tampilkan Semua";
+"Show All" = "Munculkan Semua";
 "Quit Typora" = "Keluarkan Typora";
 
 /* File Menu */
@@ -163,7 +163,7 @@
 "Clear Format" = "Bersihkan Format";
 
 /* View Menu */
-"View" = "Tampilan";
+"View" = "Tinjau";
 "New Tab" = "Bilah Baru";
 "Source Code Mode" = "Mode Kode Sumber";
 "Focus Mode" = "Mode Fokus";
@@ -174,7 +174,7 @@
 "File Tree" = "Pohon Fail";
 "Always on Top" = "Selalu di Atas";
 "Full Screen" = "Layar Penuh";
-"Show Status Bar" = "Munculkan Bilah Status"; /* to differentiate `show` (muncul) and `view` (tampil) */
+"Show Status Bar" = "Munculkan Bilah Status";
 "Toggle Fullscreen" = "(Non-)aktifkan Layar Penuh";
 "Actual Size" = "Ukuran Aktual";
 "Zoom In" = "Zum (ke) Dalam";

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -1,5 +1,4 @@
-/*
-
+/* 
   Menu.strings
   Typora
 
@@ -19,14 +18,13 @@
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
   Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
-
 */
 
 /* Typora Menu */
 
 "About Typora" = "Tentang Typora";
 "Preferences" = "Preferensi";
-"Check for Updates" = "Cek Pemutakhiran"; /* All the words `check` should be more than enough with just `cek` in Indonesian */
+"Check for Updates" = "Cek untuk Pemutakhiran"; /* All the words `check` should be more than enough with just `cek` in Indonesian */
 "Services" = "Servis"; /* See <https://kbbi.kemdikbud.go.id/entri/servis> */
 "Hide Typora" = "Sembunyikan Typora";
 "Hide Others" = "Sembunyikan Lainnya";
@@ -53,7 +51,7 @@
 "Save" = "Simpan";
 "Save As" = "Simpan sebagai"; /* `as` or `sebagai` is conjunction, so in Indonesian must start with a lowercase letter */
 "Duplicate" = "Duplikasikan"; /* See <https://kbbi.kemdikbud.go.id/entri/duplikasi>, `kan` is an affix for imperative verbs in Indonesian. */
-"Rename" = "Ubah Nama";
+"Rename" = "Namaiulang";
 "Move To" = "Pindahkan ke";
 "Revert To" = "Kembalikan ke";
 "Browse All Versions" = "Telusuri Semua Versi";
@@ -64,7 +62,7 @@
 
 /* Edit Menu */
 "Edit" = "Edit"; /* `Edit` is more accurate than `sunting`, see <https://kbbi.kemdikbud.go.id/entri/edit> */
-"Undo" = "Takjadi";
+"Undo" = "Takjadi"; /* Must be coupled, `takjadi`, cannot be separated by spaces, `tak jadi`. */
 "Redo" = "Ulangi";
 "Cut" = "Potong";
 "Copy" = "Kopi"; /* See <https://kbbi.kemdikbud.go.id/entri/kopi> which also means `salin` */
@@ -86,7 +84,7 @@
 "Jump to Selection" = "Lompat ke Seleksi";
 "Jump to Bottom" = "Lompat ke Bawah";
 "Math Tools" = "Alat Matematika";
-"Refresh All Math Expressions" = "Segarkan Semua Ekspresi Matematika"; /* all `refresh` as `segarkan` */
+"Refresh All Math Expressions" = "Segarulangkan Semua Ekspresi Matematika"; /* all `refresh` as `segarulangkan` */
 "Image Tools" = "Alat Gambar";
 "Insert Local Images" = "Sisipkan Gambar Lokal";
 "Upload Local Images via iPic" = "Unggah Gambar Lokal via iPic"; /* `via` must stay the same */
@@ -140,7 +138,7 @@
 "List Indentation" = "Lis Indentasi";
 "Indent" = "Indentasi";
 "Outdent" = "Outdentasi";
-"Link Reference" = "Referensi Pranala";
+"Link Reference" = "Referensi Tautan";
 "Footnotes" = "Catatan Kaki";
 "Horizontal Line" = "Garis Horizontal";
 "Table of Contents" = "Tabel Konten";
@@ -169,7 +167,7 @@
 "Focus Mode" = "Mode Fokus";
 "Typewriter Mode" = "Mode Mesin Tik";
 "Toggle Sidebar" = "(Non-)aktifkan Bilahsisi";
-"Outline" = "Ikhtisar";
+"Outline" = "Garisbesar";
 "Articles" = "Artikel";
 "File Tree" = "Pohon Fail";
 "Always on Top" = "Selalu di Atas";
@@ -193,14 +191,12 @@
 "Bring All to Front" = "Bawa Semua ke Front"; /* See <https://kbbi.kemdikbud.go.id/entri/front> */
 
 /* Help Menu */
-"What's New" = "Apa yang Baru"
 "Help" = "Bantuan";
 "Privacy Policy" = "Kebijakan Privasi";
 "Credits" = "Kredit";
 "Change Log" = "Log Perubahan";
 "Website" = "Situsweb";
 "Feedback" = "Umpanbalik";
-"My License…" = "Lisensi Saya";
 "About" = "Tentang";
 
 /* Touchbar */
@@ -227,12 +223,12 @@
 "Copy as Tex" = "Kopi sebagai Tex";
 "Copy Math" = "Kopi Matematika";
 "Reveal in Finder" = "Tunjukkan di Penemu"; /* `Finder` as `Penemu`, `find` as `temu` see <https://kbbi.kemdikbud.go.id/entri/penemu> */
-"Open Link" = "Buka Pranala";
+"Open Link" = "Buka Tautan";
 "Reveal in Sidebar" = "Tunjukkan di Bilahsisi";
 "Open in New Window" = "Buka di Jendela Baru";
 "Copy File Path" = "Kopi Jalur Fail";
 "New File" = "Fail Baru";
-"Rename" = "Ubah Nama";
+"Rename" = "Namaiulang";
 "New Folder" = "Folder Baru";
 
 /* Electron */
@@ -293,3 +289,56 @@
 
 "Insert Table" = "Sisipkan Tabel";
 "Insert Image" = "Sisipkan Gambar";
+"Allow Magnification" = "Izinkan Magnifikasi"; /* See <https://kbbi.kemdikbud.go.id/entri/magnifikasi> */
+
+"Move Row Up" = "Pindahkan Baris ke Atas";
+"Move Row Down" = "Pindahkan Baris Ke Bawah";
+"Move Column Left" = "Pindahkan Kolom Kiri";
+"Move Column Right" = "Pindahkan Kolom Kanan";
+
+"Zoom Image" = "Zum Gambar";
+"Zoom Image to %@" = "Zum Gambar ke %@";
+
+"Copy as Plain Text" = "Kopi sebagai Teks Biasa";
+
+"Selection" = "Selection";
+"Start Speaking" = "Mulai Berbicara";
+"Stop Speaking" = "Stop Berbicara";
+"Check Updates" = "Cek Pemutakhiran";
+
+"HTML (without Styles)" = "HTML (tanpa Gaya)";
+
+"Highlight Current Header" = "Sorot Tajuk Saat Ini";
+"Expand All" = "Ekspans Semua"; /* See <https://kbbi.kemdikbud.go.id/entri/ekspansi> */
+"Collapse All" = "Kolaps Semua"; /* See <http://tesaurus.kemdikbud.go.id/tematis/lema/kolaps> */
+"Collapsible Outline" = "Garisbesar Kolapsibel";
+"Flat Outline" = "Garisbesar Datar";
+"Articles (List View)" = "Artikel (Tinjauan Lis)";
+"File Tree (Tree View)" = "Pohon Fail (Tinjauan Pohon)";
+"Filter" = "Filter";
+
+"Upload Image" = "Unggah Gambar";
+"Upload All Local Images" = "Unggah Semua Gambar Lokal";
+"Open Image in Browser" = "Buka Gambar di Peramban"; /* See <https://kbbi.kemdikbud.go.id/entri/peramban> */
+"Copy Image" = "Kopi Gambar";
+
+"More Actions" = "Aksi Lebih";
+"Get Info" = "Dapatkan Info";
+
+"Export with Previous" = "Ekspor dengan Sebelumnya";
+"Export and Overwrite with Previous" = "Ekspor dan Timpa dengan Sebelumnya";
+
+"Emoji and Symbols" = "Emoji and Simbol";
+
+"Insert Final New Line On Save" = "Sisipkan Baris Baru Final saat Simpan";
+"Hyperlink Actions" = "Aksi Hipertaut";
+"Copy Link Address" = "Kopi Alamat Tautan";
+
+"Click" = "Klik";
+
+"Export Setting" = "Setelan Ekspor";
+
+"My License" = "Lisensi Saya";
+"Registration / Activation" = "Registrasi / Aktivasi";
+
+"Select Paragraph/Block" = "Seleksi Paragraf/Blok";

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -193,12 +193,14 @@
 "Bring All to Front" = "Bawa Semua ke Front"; /* See <https://kbbi.kemdikbud.go.id/entri/front> */
 
 /* Help Menu */
+"What's New" = "Apa yang Baru"
 "Help" = "Bantuan";
 "Privacy Policy" = "Kebijakan Privasi";
 "Credits" = "Kredit";
 "Change Log" = "Log Perubahan";
 "Website" = "Situsweb";
 "Feedback" = "Umpanbalik";
+"My License…" = "Lisensi Saya";
 "About" = "Tentang";
 
 /* Touchbar */

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -1,4 +1,5 @@
 /*
+
   Menu.strings
   Typora
 
@@ -46,8 +47,8 @@
 "No Recent Files" = "Tiada Fail Terkini";
 "Open Quickly" = "Buka Segera"; /* all `quick` or `quickly` as `segera`, for context see <https://kbbi.kemdikbud.go.id/entri/segera> */
 "Open File Location" = "Buka Lokasi Fail";
-"Reveal in Library" = "Ungkapkan dalam Pustaka";
-"Reveal in File Tree" = "Ungkapkan dalam Pohon Fail";
+"Reveal in Library" = "Tunjukkan dalam Pustaka";
+"Reveal in File Tree" = "Tunjukkan dalam Pohon Fail";
 "Close" = "Tutup";
 "Save" = "Simpan";
 "Save As" = "Simpan sebagai"; /* `as` or `sebagai` is conjunction, so in Indonesian must start with a lowercase letter */
@@ -96,7 +97,7 @@
 "Line Endings" = "Akhiran Baris";
 "Windows Line Endings (CRLF)" = "Akhiran Baris Windows (CRLF)";
 "Unix Line Endings (LF)" = "Akhiran Baris Unix (LF)";
-"Find" = "Temukan";
+"Find" = "Temukan"; /* `Find` as `Temu`. `-kan` is command word, see <https://kbbi.kemdikbud.go.id/entri/temu> */
 "Find Next" = "Temukan Berikutnya";
 "Find Previous" = "Temukan Sebelumnya";
 "Find and Replace" = "Temukan dan Ganti";
@@ -223,9 +224,9 @@
 "Copy as MathML" = "Kopi sebagai MathML";
 "Copy as Tex" = "Kopi sebagai Tex";
 "Copy Math" = "Kopi Matematika";
-"Reveal in Finder" = "Tampilkan di Finder";
+"Reveal in Finder" = "Tunjukkan di Penemu"; /* `Finder` as `Penemu`, `find` as `temu` see <https://kbbi.kemdikbud.go.id/entri/penemu> */
 "Open Link" = "Buka Pranala";
-"Reveal in Sidebar" = "Tampilkan di Bilahsisi";
+"Reveal in Sidebar" = "Tunjukkan di Bilahsisi";
 "Open in New Window" = "Buka di Jendela Baru";
 "Copy File Path" = "Kopi Jalur Fail";
 "New File" = "Fail Baru";

--- a/id-ID.lproj/Menu.strings
+++ b/id-ID.lproj/Menu.strings
@@ -41,7 +41,7 @@
 "Open Folder" = "Buka Folder";
 "Reopen with Encoding" = "Buka Kembali dengan Pengkodean"; /* Standard word is `pengkodean`, not `pengodean`. See <https://kbbi.kemdikbud.go.id/entri/pengkodean> */
 "Auto" = "Oto";
-"Open Recent" = "Buka (Fail) Terkini"; /* `fail` is an insert, it's better to put brackets */
+"Open Recent" = "Buka Terkini";
 "Recent Locations" = "Lokasi Terkini";
 "Clear Items" = "Bersihkan Item";
 "No Recent Files" = "Tiada Fail Terkini";

--- a/id-ID.lproj/Panel.strings
+++ b/id-ID.lproj/Panel.strings
@@ -43,7 +43,7 @@
 "Left Panel" = "Panel Kiri";
 "Show Outline Panel by Default" = "Tampilkan Panel Ikhtisar sebagai Asali"; /* See <https://kbbi.kemdikbud.go.id/entri/asali> */
 "Collapsible Outline on Left Panel" = "Ikhtisar yang dapat dilipat pada Panel Kiri";
-"Save without asking when\nswitch files on side panel" = "Simpan tanpa pertanyaan ketika\nberalih berkas pada panel sisi";
+"Save without asking when\nswitch files on side panel" = "Simpan tanpa pertanyaan ketika\nberalih fail pada panel sisi"; /* `Fail` is more accurate than `berkas`, but see <https://kbbi.kemdikbud.go.id/entri/fail> */
 "Language" = "Bahasa";
 "System Language" = "Bahasa Sistem";
 
@@ -100,34 +100,34 @@
 /* Pandoc Import Panel */
 "Importing..." = "Pengimporan...";
 "Importing in progress..." = "Pengimporan dalam progres..."; /* See <https://kbbi.kemdikbud.go.id/entri/progres> */
-"Converting file with Pandoc. This may take some time." = "Mengonversi berkas dengan Pandoc. Ini mungkin memakan waktu sebentar.";
+"Converting file with Pandoc. This may take some time." = "Mengonversi fail dengan Pandoc. Ini mungkin memakan waktu sebentar.";
 "Abort" = "Gugurkan";
 
 /* Pandoc Export Panel */
 "Exporting..." = "Pengeksporan...";
 "Exporting in progress..." = "Pengeksporan dalam progress...";
-"Converting file with Pandoc. This may take some time." = "Mengonversi berkas dengan Pandoc. Ini mungkin memakan waktu sebentar.";
+"Converting file with Pandoc. This may take some time." = "Mengonversi fail dengan Pandoc. Ini mungkin memakan waktu sebentar.";
 
 /* Export & Import */
-"Pandoc is needed for importing these file formats" = "Pandoc diperlukan untuk mengimpor format berkas ini";
+"Pandoc is needed for importing these file formats" = "Pandoc diperlukan untuk mengimpor format fail ini";
 "Check help->Install and use Pandoc from menubar for detail" = "Cek bantuan->Instal dan gunakan Pandoc dari bilah menu untuk detail";
 "Import or some export features requires <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) to be installed." = "Fitur impor atau beberapa ekspor memerlukan <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) untuk diinstal.";
 "Follow Instructions to Install/Update Pandoc" = "Ikuti Instruksi untuk Instal/Pemutakhiran Pandoc"; /* See <https://kbbi.kemdikbud.go.id/entri/pemutakhiran> */
 "Export Failed" = "Ekspor Gagal";
 "Import Failed" = "Impor Gagal";
 "Generated Image too Large" = "Gambar yang Dihasilkan Terlalu Besar";
-"Failed to export file to <em>{0}</em>" = "Gagal ekspor berkas ke <em>{0}</em>";
-"Failed to import file from <em>{0}</em>" = "Gagal impor berkas dari <em>{0}</em>";
-"File does not exist at <em>{0}</em>" = "Berkas tidak eksis di <em>{0}</em>";
+"Failed to export file to <em>{0}</em>" = "Gagal ekspor fail ke <em>{0}</em>";
+"Failed to import file from <em>{0}</em>" = "Gagal impor fail dari <em>{0}</em>";
+"File does not exist at <em>{0}</em>" = "Fail tidak eksis di <em>{0}</em>";
 "Export to..." = "Ekspor ke...";
 "Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "Apakah Anda ingin menyimpan perubahan yang dibuat pada dokumen ini ?<br> Perubahan Anda akan hilang jika Anda tidak menyimpannya.";
-"[Warning] Failed to attach bookmark for PDF file." = "[Peringatan] Gagal melampirkan markahbuku untuk berkas PDF."; /* See <https://kbbi.kemdikbud.go.id/entri/markah> and <https://kbbi.kemdikbud.go.id/entri/buku> */
+"[Warning] Failed to attach bookmark for PDF file." = "[Peringatan] Gagal melampirkan markahbuku untuk fail PDF."; /* See <https://kbbi.kemdikbud.go.id/entri/markah> and <https://kbbi.kemdikbud.go.id/entri/buku> */
 "Dark Theme not support" = "Tema Gelap tidak mendukung";
 "Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Maaf, versi Typora saat ini tidak akan mencetak warna latarbelakang pada PDF yang diekspor, jadi proses ekspor PDF belum mendukung tema gelap. \nSila pilihlah mode terang atau pilih \"Cetak dengan tema asali\"";
 "Print with default theme" = "Cetak dengan tema asali";
 "Export to PDF successfully." = "Ekspor ke PDF sukses secara penuh.";
-"Converting file using Pandoc. This may take some time." = "Konversi berkas menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
-"Exporting file using Pandoc. This may take some time." = "Mengekspor berkas menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
+"Converting file using Pandoc. This may take some time." = "Konversi fail menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
+"Exporting file using Pandoc. This may take some time." = "Mengekspor fail menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
 
 /* Upload via iPic */
 "Uploading Images via iPic..." = "Pengunggahan Gambar via iPic...";
@@ -161,7 +161,7 @@
 "Trigger by ESC key" = "Picu dengan kunci ESC";
 "Trigger automatically" = "Picu secara otomatis";
 "Default Line Ending" = "Akhir Baris Asali";
-"Line ending for new file" = "Akhir baris untuk berkas baru";
+"Line ending for new file" = "Akhir baris untuk fail baru";
 "Spell Check" = "Cek Ejaan";
 "Auto correct spelling" = "Oto koreksi ejaan";
 "System" = "Sistem";
@@ -181,24 +181,24 @@
 "This feature require macOS >= 10.11" = "Fitur ini memerlukan macOS >= 10.11";
 "One More Step" = "Satu Step Lagi"; /* See <https://kbbi.kemdikbud.go.id/entri/step> */
 "Notice" = "Maklumat"; /* See <https://kbbi.kemdikbud.go.id/entri/maklumat> */
-"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan iPic untuk diinstal, dan berkas gambar yang diacu akan diunggah ke layanan awan via iPic. Mohon juga catat bahwa layanan awan bawaan tidak mendukung penghapusan gambar yang diunggah.";
+"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan iPic untuk diinstal, dan fail gambar yang diacu akan diunggah ke layanan awan via iPic. Mohon juga catat bahwa layanan awan bawaan tidak mendukung penghapusan gambar yang diunggah.";
 
 "%d Images Failed to Upload." = "%d Gambar Gagal Diunggah.";
 "%d Succeeded," = "%d Sukses, ";
 "Enable this feature on preferences panel" = "Aktifkan fitur ini pada panel preferensi";
-"%@ is a file, not a directory" = "%@ adalah sebuah berkas, bukan folder";
+"%@ is a file, not a directory" = "%@ adalah sebuah fail, bukan folder";
 "Copy Images To…" = "Kopi Gambar ke…";
 "Typora are trying copy the newly inserted image to folder %@ according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru dimasukkan ke folder %@ sesuai dengan pengaturan YAML Front Matter atau preferensi global Anda. Namun, terget folder tidak eksis. Buat folder tersebut sekarang?";
 "Create Folder and Continue" = "Buat Folder dan Lanjutkan";
 "Document must be saved first" = "Dokumen harus disimpan dahulu";
-"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora akan mengopi gambar yang baru dimasukkan ke folder dengan jalur relatif yang diseleksi, jadi mohon simpan berkas tersebut dahulu.";
+"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora akan mengopi gambar yang baru dimasukkan ke folder dengan jalur relatif yang diseleksi, jadi mohon simpan fail tersebut dahulu.";
 "Open Operation Failed" = "Operasi Buka Gagal"; /* See <https://kbbi.kemdikbud.go.id/entri/operasi> */
 
 "Support Documentation" = "Dokumentasi Dukungan";
 
-"Markdown File" = "Berkas Markdown";
-"Plain Text File" = "Berkas Teks Biasa";
-"All Files" = "Semua Berkas";
+"Markdown File" = "Fail Markdown";
+"Plain Text File" = "Fail Teks Biasa";
+"All Files" = "Semua Fail";
 "All Supported Formats" = "Semua Format yang Didukung";
 "Discard Changes" = "Buanglah Perubahan";
 "Discard" = "Buanglah";
@@ -212,11 +212,11 @@
 "Recent Documents" = "Dokumen Terkini";
 "Search for" = "Cari untuk";
 "Clear Recent Documents" = "Bersihkan Dokumen Terkini";
-"File Name" = "Nama Berkas";
+"File Name" = "Nama Fail";
 "Path" = "Jalur";
 "Export As..." = "Ekspor sebagai...";
 "More Formats" = "Format Lain";
-"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Format berkas dalam 'Format Lain' memerlukan <a class='open-pandoc-guide'>Pandoc untuk diinstall</a>.";
+"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Format fail dalam 'Format Lain' memerlukan <a class='open-pandoc-guide'>Pandoc untuk diinstall</a>.";
 "Something is Wrong…" = "Ada Sesuatu yang Salah……";
 "Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control//'>Recover lost contents</a></li></ul>" = "Penyimpanan konten gagal dengan sejumlah alasan.<br/>Anda dapat menyalin konten ke jendela baru Typora, kemudian simpan. <br/>Pelajari lagi tentang:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Laporkan bug ke kami</a></li><li><a href='https://support.typora.io/Version-Control//'>Pulihkan konten yang hilang</a></li></ul>";
 "Copy Content" = "Kopi Konten";
@@ -251,9 +251,9 @@
 "Quit" = "Keluar";
 "Quit Typora when last window is closed" = "Keluarkan Typora ketika jendela terakhir ditutup";
 "On Launch" = "Sedang Diluncurkan";
-"Open new file" = "Buka berkas baru";
+"Open new file" = "Buka fail baru";
 "Restore last closed folders" = "Pulihkan folder yang ditutup terakhir";
-"Restore last closed files and folders" = "Pulihkan berkas dan folder yang ditutup terakhir";
+"Restore last closed files and folders" = "Pulihkan fail dan folder yang ditutup terakhir";
 "Open custom folder" = "Buka folder kostum";
 "Select custom folder" = "Seleksi folder kostum";
 "This option may be overridden by \"Close windows when quitting an application\" in System Preferences" = "Opsi ini mungkin akan ditimpa oleh \"Tutup jendela ketika keluar dari aplikasi\" di Preferensi Sistem";
@@ -264,14 +264,14 @@
 "<div>Recognize unicode punctuations as ASCII ones when parse markdown, e.g:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>It will be turned on automatically if smart quotes/dashes will be converted on input.<div>" = "<div>Rekognisikan pungtuasi unikode sebagai ASCII ketika menguraikan markdown, contoh:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>Ini akan diaktifkan secara otomatis jika kutipan/tanda hubung cerdas akan dikonversi pada input.<div>";
 
 "Copy image to custom folder" = "Kopi gambar ke folder kostum";
-"Please specify a relative path to current folder which begins with './' or '../', or an absolute folder path. (`${filename}` representing for currents filename.)" = "Mohon spesifikasikan jalur relatif ke folder saat ini (dimulai dengan './' or '../') atau jalur folder absolut. (`${filename}` mewakili nama berkas saat ini.)";
+"Please specify a relative path to current folder which begins with './' or '../', or an absolute folder path. (`${filename}` representing for currents filename.)" = "Mohon spesifikasikan jalur relatif ke folder saat ini (dimulai dengan './' or '../') atau jalur folder absolut. (`${filename}` mewakili nama fail saat ini.)";
 "Restore to previous setting" = "Pulihkan ke pengaturan sebelumnya";
 "Folder not exist at %@, please input another path." = "Folder tidak eksis di %@, mohon input jalur lain.";
 "Please input a folder path." = "Mohon input jalur folder.";
 "Cannot use root path." = "Takdapat menggunakan jalur akar.";
 
 "Get Themes" = "Dapatkan Tema";
-"File/directory already exists at target path." = "Berkas/direktori sudah eksis di jalur target.";
+"File/directory already exists at target path." = "Fail/direktori sudah eksis di jalur target.";
 "Keep Both" = "Simpan Keduanya";
 "Are you sure you want to move %@?" = "Apakah Anda yakin Anda ingin memindahkan %@?";
 
@@ -283,7 +283,7 @@
 "Dialog warnings have been reset." = "Peringatan dialog telah direset.";
 
 "Operation Failed" = "Operasi Gagal";
-"Failed to move target file or folder to trash" = "Gagal memindahkan berkas atau folder tujuan ke tongsampah";
+"Failed to move target file or folder to trash" = "Gagal memindahkan fail atau folder tujuan ke tongsampah";
 
 "Undo %@" = "Takjadi %@";
 "Rename %@" = "Ubah Nama %@";

--- a/id-ID.lproj/Panel.strings
+++ b/id-ID.lproj/Panel.strings
@@ -1,13 +1,26 @@
 /*
+
  Panel.strings
  translations for preference panel and other dialogs
 
  by hi@typora.io
 
- Indonesian (Bahasa Indonesia) translation
- by Samuel Natalius (@snatalius)
- samnatalius[at]outlook[dot]com
- */
+ Indonesian (Bahasa Indonesia) Translation
+ by Samuel Natalius <https://github.com/snatalius> <samnatalius@outlook.com>,
+    Kylamber <https://github.com/Kylamber> <>,
+    Nashrullah Ali Fauzi <https://github.com/nashrullahalifauzi> <nash@nashrullahalifauzi.com>.
+
+  Notice:
+
+  If there is an loanword in the Indonesian dictionary, then use it in Typora. For example, if in English there is the word `font`, then in standard Indonesian it should be written `fon` without the letter `t`, even though there is a non-standard word, `fonta` which has the same meaning.
+
+  Likewise with the word 'input' in English, when it is translated into Indonesian it does not change, because the word 'input' in the Indonesian dictionary, also has the same meaning in English. It is not appropriate to translate the English word 'input' as 'masukan' in Indonesian. This is an attempt to keep the language of the app, especially Typora, from straying too far from its native language as default.
+
+  `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
+
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+
+*/
 
 /* Preference Panel */
 "Preferences" = "Preferensi";
@@ -20,105 +33,105 @@
 "Seamless window only support OS X later than 10.10." = "Jendela yang mulus hanya didukung oleh OS X versi lebih baru daripada 10.10.";
 "Themes" = "Tema";
 "Open Theme Folder" = "Buka Folder Tema";
-"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Silakan buka `help`->`Quick Start` untuk pengenalan singkat. Kunjungi http://theme.typora.io to mendapatkan lebih banyak tema atau instruksi.";
-"Word Count" = "Perhitungan Kata";
-"Always Show Word Count" = "Selalu Tampilkan Perhitungan Kata";
-"Font Size" = "Ukuran Huruf";
-"Auto ( Recommended )" = "Otomatis ( Direkomendasikan )";
-"Customized" = "Disesuaikan";
-"If custom font size is used, the actual font size will depend on the base font size and css style." = "Jika ukuran huruf lepas digunakan, ukuran huruf yang sebenarnya akan bergantung pada ukuran huruf dasar dan gaya css.";
+"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Silakan cek `bantuan`->`Mulai Segera` untuk introduksi pendek. Kunjungi http://theme.typora.io untuk mendapatkan lebih banyak tema atau instruksi.";
+"Word Count" = "Jumlah Kata";
+"Always Show Word Count" = "Selalu Tampilkan Jumlah Kata";
+"Font Size" = "Ukuran Fon"; /* See <https://kbbi.kemdikbud.go.id/entri/fon> */
+"Auto ( Recommended )" = "Oto ( Direkomendasikan )";
+"Customized" = "Dikostumisasi";
+"If custom font size is used, the actual font size will depend on the base font size and css style." = "Jika ukuran fon kustom digunakan, ukuran fon aktual akan bergantung pada ukuran fon dan gaya css dasar.";
 "Left Panel" = "Panel Kiri";
-"Show Outline Panel by Default" = "Tampilkan Panel Ikhtisar sebagai standar";
+"Show Outline Panel by Default" = "Tampilkan Panel Ikhtisar sebagai Asali"; /* See <https://kbbi.kemdikbud.go.id/entri/asali> */
 "Collapsible Outline on Left Panel" = "Ikhtisar yang dapat dilipat pada Panel Kiri";
-"Save without asking when\nswitch files on side panel" = "Simpan tanpa pertanyaan ketika\nberpindah file pada panel sisi";
+"Save without asking when\nswitch files on side panel" = "Simpan tanpa pertanyaan ketika\nberalih berkas pada panel sisi";
 "Language" = "Bahasa";
 "System Language" = "Bahasa Sistem";
 
 /* Editor Panel */
 "Editor" = "Editor";
-"Indent Size on Save" = "Anjurkan Ukuran saat Menyimpan";
-"only apply to quotes and lists created from menu bar or hybrid view" = "terapkan hanya untuk kutipan dan daftar yang dibuat dari bilah menu atau tinjauan campuran";
-"Trigger Autocomplete without ESC key for" = "Aktifkan Autocomplete tanpa tombol ESC untuk";
+"Indent Size on Save" = "Ukuran indentasi saat Menyimpan";
+"only apply to quotes and lists created from menu bar or hybrid view" = "hanya terapkah untuk kutipan dan lis yang dibuat dari bilah menu atau tampilan hibrida";
+"Trigger Autocomplete without ESC key for" = "Picu Otokomplet tanpa kunci ESC untuk"; /* `Otokomplet` is standard word `autocomplete` */
 "Emoji (e.g. :smile:)" = "Emoji (contoh: :smile:)";
 "Images Insert" = "Penyisipan Gambar";
-"Use relative path if possible" = "Gunakan path relatif jika memungkinkan";
-"Auto Pair" = "Pasangkan secara otomatis";
-"Auto pair brackets and quotes" = "Pasangkan tanda kurung dan kutip secara otomatis";
-"Auto pair common Markdown syntax" = "Pasangkan sintaksis Markdown umum secara otomatis";
-"Live Rendering" = "Rendering secara langsung";
-"Display source for simple blocks\n(including headings, etc.) on focus" = "Tampilkan sumber untuk blok sederhana\n(mencakup heading, dll.) saat fokus";
-"Default Copy Behavior" = "Aturan Penyalinan Standar";
-"Copy Markdown source as plain text" = "Salin sumber Markdown sebagai teks biasa";
+"Use relative path if possible" = "Gunakan jalur relatif jika memungkinkan";
+"Auto Pair" = "Oto Pasangkan";
+"Auto pair brackets and quotes" = "Oto pasangkan tanda kurung dan kutip";
+"Auto pair common Markdown syntax" = "Oto pasangkan sintaksis Markdown umum";
+"Live Rendering" = "Perenderan Langsung";
+"Display source for simple blocks\n(including headings, etc.) on focus" = "Dispaikan sumber untuk blok simpel\n(mencakup tajuk, dll.) saat fokus"; /* See <https://kbbi.kemdikbud.go.id/entri/simpel> */
+"Default Copy Behavior" = "Perilaku Kopi Asali";
+"Copy Markdown source as plain text" = "Kopi sumber Markdown sebagai teks biasa";
 "Typewriter Mode" = "Mode Mesin Tik";
-"Always keep caret in middle of screen\nwhen typewriter mode is enabled" = "Selalu letakkan kursor di tengah layar\nsaat mode mesin tik diaktifkan";
+"Always keep caret in middle of screen\nwhen typewriter mode is enabled" = "Selalu letakkan caret di tengah layar\nketika mode mesin tik diaktifkan"; /* See <https://kbbi.kemdikbud.go.id/entri/caret> */
 
 /* Markdown Panel */
 "Markdown" = "Markdown";
-"(Following preferences will be applied after restart.)" = "(Preferensi ini akan diterapkan setelah restart.)";
+"(Following preferences will be applied after restart.)" = "(Preferensi berikut akan diterapkan setelah kembali mulai.)";
 "Syntax Support" = "Bantuan Sintaksis";
 "Inline Math  ( e.g: $\LaTeX$ )" = "Matematika Sebaris  ( e.g: $\LaTeX$ )";
-"Subscript    ( e.g: H~2~O )" = "Tika bawah    ( e.g: H~2~O )";
-"Superscript ( e.g: X^2^ )" = "Tika atas ( e.g: X^2^ )";
+"Subscript    ( e.g: H~2~O )" = "Subskrip    ( e.g: H~2~O )";
+"Superscript ( e.g: X^2^ )" = "Superskrip ( e.g: X^2^ )";
 "Highlight     (e.g: ==key==)" = "Sorotan     (e.g: ==key==)";
 "Diagrams" = "Diagram";
-"(Sequence, Flowchart and Mermaid)" = "(Sequence, Flowchart and Mermaid)";
+"(Sequence, Flowchart and Mermaid)" = "(Sekuens, Diagram Alir dan Mermaid)"; /* See <https://id.wikipedia.org/wiki/Diagram_alir> */
 "Syntax Preference" = "Preferensi Sintaksis";
-"(only applies to styles created from menubar or hybrid view)" = "(terapkan hanya kepada gaya yang dibuat dari bilah menu atau tinjauan campuran)";
+"(only applies to styles created from menubar or hybrid view)" = "(hanya terapkan terhadap gaya yang dibuat dari bilah menu atau tampilan hibrida)";
 "Strict Mode" = "Mode Ketat";
-"(more strict to GFM spec)" = "(lebih ketat ke GFM spec)";
-"Heading Style" = "Gaya Heading";
-"Unordered List" = "Daftar Tidak Terurut";
-"Ordered List" = "Daftar Terurut";
-"Code Fences" = "Kotak Kode";
-"Display line numbers for code fences" = "Tampilkan nomor baris pada Kotak Kode";
+"(more strict to GFM spec)" = "(lebih ketat ke spesifikasi GFM)";
+"Heading Style" = "Gaya Tajuk";
+"Unordered List" = "Lis Takberurut";
+"Ordered List" = "Lis Berurut";
+"Code Fences" = "Pagar Kode";
+"Display line numbers for code fences" = "Displaikan nomor baris pada pagar kode";
 "Math Blocks" = "Blok Matematika";
-"Auto Numbering Math Equations" = "Nomori Persamaan Matematika secara otomatis";
+"Auto Numbering Math Equations" = "Oto penomoran ekuasi Matematika"; /* See <https://kbbi.kemdikbud.go.id/entri/ekuasi> */
 
 /* Security Panel */
 "Security" = "Keamanan";
 "Enable Debug" = "Aktifkan Debug";
-"Send Anonymous Usage Info" = "Kirim informasi anonim tentang penggunaan.";
+"Send Anonymous Usage Info" = "Kirimkan Info Penggunaan Anonim";
 
 /* Pandoc Error Panel */
 "Require Pandoc to Continue..." = "Perlu Pandoc untuk Lanjut...";
-"Follow instructions to install Pandoc" = "Ikuti instruksi untuk memasang Pandoc";
+"Follow instructions to install Pandoc" = "Ikuti instruksi untuk menginstal Pandoc";
 "Cancel" = "Batalkan";
 
 /* Pandoc Import Panel */
-"Importing..." = "Mengimpor...";
-"Importing in progress..." = "Sedang mengimpor...";
-"Converting file with Pandoc. This may take some time." = "Mengonversikan file dengan Pandoc. Ini mungkin memakan waktu sebentar.";
-"Abort" = "Batalkan";
+"Importing..." = "Pengimporan...";
+"Importing in progress..." = "Pengimporan dalam progres..."; /* See <https://kbbi.kemdikbud.go.id/entri/progres> */
+"Converting file with Pandoc. This may take some time." = "Mengonversi berkas dengan Pandoc. Ini mungkin memakan waktu sebentar.";
+"Abort" = "Gugurkan";
 
 /* Pandoc Export Panel */
-"Exporting..." = "Mengekspor...";
-"Exporting in progress..." = "Sedang mengekspor...";
-"Converting file with Pandoc. This may take some time." = "Mengonversikan file dengan Pandoc. Ini mungkin memakan waktu sebentar.";
+"Exporting..." = "Pengeksporan...";
+"Exporting in progress..." = "Pengeksporan dalam progress...";
+"Converting file with Pandoc. This may take some time." = "Mengonversi berkas dengan Pandoc. Ini mungkin memakan waktu sebentar.";
 
 /* Export & Import */
-"Pandoc is needed for importing these file formats" = "Pandoc diperlukan untuk mengimpor format file ini";
-"Check help->Install and use Pandoc from menubar for detail" = "Periksa bantuan->Pasang dan gunakan Pandoc dari bilah menu untuk rincian";
-"Import or some export features requires <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) to be installed." = "Fitur impor atau beberapa fitur ekspor memerlukan pemasangan <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0).";
-"Follow Instructions to Install/Update Pandoc" = "Ikuti Instruksi untuk Memasang/Memperbarui Pandoc";
+"Pandoc is needed for importing these file formats" = "Pandoc diperlukan untuk mengimpor format berkas ini";
+"Check help->Install and use Pandoc from menubar for detail" = "Cek bantuan->Instal dan gunakan Pandoc dari bilah menu untuk detail";
+"Import or some export features requires <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) to be installed." = "Fitur impor atau beberapa ekspor memerlukan <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) untuk diinstal.";
+"Follow Instructions to Install/Update Pandoc" = "Ikuti Instruksi untuk Instal/Pemutakhiran Pandoc"; /* See <https://kbbi.kemdikbud.go.id/entri/pemutakhiran> */
 "Export Failed" = "Ekspor Gagal";
 "Import Failed" = "Impor Gagal";
 "Generated Image too Large" = "Gambar yang Dihasilkan Terlalu Besar";
-"Failed to export file to <em>{0}</em>" = "Gagal mengekspor file ke <em>{0}</em>";
-"Failed to import file from <em>{0}</em>" = "Gagal mengimpor file dari <em>{0}</em>";
-"File does not exist at <em>{0}</em>" = "File tidak ada di <em>{0}</em>";
+"Failed to export file to <em>{0}</em>" = "Gagal ekspor berkas ke <em>{0}</em>";
+"Failed to import file from <em>{0}</em>" = "Gagal impor berkas dari <em>{0}</em>";
+"File does not exist at <em>{0}</em>" = "Berkas tidak eksis di <em>{0}</em>";
 "Export to..." = "Ekspor ke...";
-"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "Apakah kamu ingin menyimpan perubahan terhadap dokumen ini ?<br> Perubahan yang Anda buat akan hilang bila tidak disimpan.";
-"[Warning] Failed to attach bookmark for PDF file." = "[Peringatan] Gagal melampirkan bookmark untuk file PDF.";
+"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "Apakah Anda ingin menyimpan perubahan yang dibuat pada dokumen ini ?<br> Perubahan Anda akan hilang jika Anda tidak menyimpannya.";
+"[Warning] Failed to attach bookmark for PDF file." = "[Peringatan] Gagal melampirkan markahbuku untuk berkas PDF."; /* See <https://kbbi.kemdikbud.go.id/entri/markah> and <https://kbbi.kemdikbud.go.id/entri/buku> */
 "Dark Theme not support" = "Tema Gelap tidak mendukung";
-"Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Maaf, versi Typora saat ini tidak akan mencetak warna latar belakang pada PDF yang diekspor, Jadi proses ekspor PDF belum mendukung tema gelap. \nSilakan pilih mode terang atau pilih opsi \"Cetak dengan tema standar\"";
-"Print with default theme" = "Cetak dengan tema standar";
-"Export to PDF successfully." = "Ekspor ke PDF berhasil.";
-"Converting file using Pandoc. This may take some time." = "Konversi file menggunakan Pandoc. Ini mungkin memakan waktu sebentar.";
-"Exporting file using Pandoc. This may take some time." = "Mengekspor file menggunakan Pandoc. Ini mungkin memakan waktu sebentar.";
+"Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Maaf, versi Typora saat ini tidak akan mencetak warna latarbelakang pada PDF yang diekspor, jadi proses ekspor PDF belum mendukung tema gelap. \nSila pilihlah mode terang atau pilih \"Cetak dengan tema asali\"";
+"Print with default theme" = "Cetak dengan tema asali";
+"Export to PDF successfully." = "Ekspor ke PDF sukses secara penuh.";
+"Converting file using Pandoc. This may take some time." = "Konversi berkas menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
+"Exporting file using Pandoc. This may take some time." = "Mengekspor berkas menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
 
 /* Upload via iPic */
-"Uploading Images via iPic..." = "Mengunggah Gambar melalui iPic...";
-"Uploading in progress…" = "Sedang mengunggah...";
+"Uploading Images via iPic..." = "Pengunggahan Gambar via iPic...";
+"Uploading in progress…" = "Pengunggahan dalam progres...";
 "Do not show this again" = "Jangan tampilkan ini kembali";
 
 /* Word Count */
@@ -131,149 +144,149 @@
 "Lines" = "Baris";
 "Words" = "Kata";
 "Characters" = "Karakter";
-"In Selection" = "Dalam Pilihan";
+"In Selection" = "Dalam Seleksi";
 "Panel" = "Panel";
 
 /* Windows Prefernce Panel*/
 "Appearance" = "Penampilan";
-"System Native" = "Sistem Asli";
-"Unibody" = "Unibody";
-"(applied after restart)" = "(diterapkan setelah restart)";
+"System Native" = "Sistem Natif";
+"Unibody" = "Unibodi"; /* Combined words, see <https://kbbi.kemdikbud.go.id/entri/uni> and <https://kbbi.kemdikbud.go.id/entri/bodi> */
+"(applied after restart)" = "(diterapkan setelah kembali mulai)";
 "Status Bar" = "Bilah Status";
-"Show status bar" = "Tampilkan bilah status";
-"Save & Recover" = "Simpan & Dapatkan Kembali";
-"Auto Save" = "Simpan Secara Otomatis";
-"Recover Unsaved Drafts" = "Dapatkan Kembali Draf yang Tidak Tersimpan";
-"Emoji Autocomplete" = "Emoji Autocomplete";
-"Trigger by ESC key" = "Aktifkan dengan tombol ESC";
-"Trigger automatically" = "Aktifkan secara otomatis";
-"Default Line Ending" = "Akhiran Baris Standar";
-"Line ending for new file" = "Akhiran baris untuk file baru";
-"Spell Check" = "Pemeriksaan Ejaan";
-"Auto correct spelling" = "Perbaiki ejaan secara otomatis";
+"Show status bar" = "Munculkan bilah status"; /* to differentiate `show` (muncul) and `view` (tampil) */
+"Save & Recover" = "Simpan & Pulihkan";
+"Auto Save" = "Oto Simpan";
+"Recover Unsaved Drafts" = "Pulihkan Draf yang Taktersimpan";
+"Emoji Autocomplete" = "Otokomplet Emoji";
+"Trigger by ESC key" = "Picu dengan kunci ESC";
+"Trigger automatically" = "Picu secara otomatis";
+"Default Line Ending" = "Akhir Baris Asali";
+"Line ending for new file" = "Akhir baris untuk berkas baru";
+"Spell Check" = "Cek Ejaan";
+"Auto correct spelling" = "Oto koreksi ejaan";
 "System" = "Sistem";
 "Privacy" = "Privasi";
 "Developer" = "Pengembang";
-"Update" = "Pembaruan";
-"Check Updates" = "Periksa Pembaruan";
-"Check updates automatically" = "Periksa pembaruan secara otomatis";
-"Advanced Settings" = "Pengaturan Lanjutan";
-"Open Advanced Settings" = "Buka Pengaturan Lanjutan";
-"Reset Advanced Settings" = "Atur Ulang Pengaturan Lanjutan";
+"Update" = "Pemutakhiran";
+"Check Updates" = "Cek Pemutakhiran";
+"Check updates automatically" = "Cek Pemutakhiran secara otomatis";
+"Advanced Settings" = "Setelan Lanjutan";
+"Open Advanced Settings" = "Buka Setelan Lanjutan";
+"Reset Advanced Settings" = "Reset Setelan Lanjutan"; /* See <https://kbbi.kemdikbud.go.id/entri/reset> */
 
 /* Image relates on macOS */
-"This function requires latest version of iPic to be installed." = "Fungsi ini memerlukan pemasangan iPic versi terkini.";
+"This function requires latest version of iPic to be installed." = "Fungsi ini memerlukan versi terkini atas iPic untuk diinstal.";
 "Get iPic" = "Dapatkan iPic";
-"Cannot Continue…" = "Tidak Dapat Melanjutkan…";
+"Cannot Continue…" = "Takdapat Lanjut…";
 "This feature require macOS >= 10.11" = "Fitur ini memerlukan macOS >= 10.11";
-"One More Step" = "Satu Langkah Lagi";
-"Notice" = "Pemberitahuan";
-"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan pemasangan iPic, dan file gambar yang diacu akan diunggah ke layanan cloud melalui iPic. Mohon diperhatikan bahwa layanan cloud standar tidak mendukung penghapusan gambar yang diunggah.";
+"One More Step" = "Satu Step Lagi"; /* See <https://kbbi.kemdikbud.go.id/entri/step> */
+"Notice" = "Maklumat"; /* See <https://kbbi.kemdikbud.go.id/entri/maklumat> */
+"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan iPic untuk diinstal, dan berkas gambar yang diacu akan diunggah ke layanan awan via iPic. Mohon juga catat bahwa layanan awan bawaan tidak mendukung penghapusan gambar yang diunggah.";
 
 "%d Images Failed to Upload." = "%d Gambar Gagal Diunggah.";
-"%d Succeeded," = "%d Berhasil, ";
+"%d Succeeded," = "%d Sukses, ";
 "Enable this feature on preferences panel" = "Aktifkan fitur ini pada panel preferensi";
-"%@ is a file, not a directory" = "%@ adalah file, bukan folder";
-"Copy Images To…" = "Salin Gambar Ke…";
-"Typora are trying copy the newly inserted image to folder %@ according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora sedang berusaha untuk menyalin gambar yang baru disisipkan ke folder %@ sesuai dengan aturan YAML Front Matter atau preferensi global Anda. Namun, folder tujuan belum ada. Buat folder tersebut sekarang?";
+"%@ is a file, not a directory" = "%@ adalah sebuah berkas, bukan folder";
+"Copy Images To…" = "Kopi Gambar ke…";
+"Typora are trying copy the newly inserted image to folder %@ according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru dimasukkan ke folder %@ sesuai dengan pengaturan YAML Front Matter atau preferensi global Anda. Namun, terget folder tidak eksis. Buat folder tersebut sekarang?";
 "Create Folder and Continue" = "Buat Folder dan Lanjutkan";
-"Document must be saved first" = "Dokumen harus disimpan terlebih dahulu";
-"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora akan menyalin gambar yang baru disisipkan ke folder dengan path relatif yang dipilih, jadi mohon simpan file tersebut terlebih dahulu.";
-"Open Operation Failed" = "Operasi Buka Gagal";
+"Document must be saved first" = "Dokumen harus disimpan dahulu";
+"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora akan mengopi gambar yang baru dimasukkan ke folder dengan jalur relatif yang diseleksi, jadi mohon simpan berkas tersebut dahulu.";
+"Open Operation Failed" = "Operasi Buka Gagal"; /* See <https://kbbi.kemdikbud.go.id/entri/operasi> */
 
 "Support Documentation" = "Dokumentasi Dukungan";
 
-"Markdown File" = "File Markdown";
-"Plain Text File" = "File Teks Biasa";
-"All Files" = "Semua File";
+"Markdown File" = "Berkas Markdown";
+"Plain Text File" = "Berkas Teks Biasa";
+"All Files" = "Semua Berkas";
 "All Supported Formats" = "Semua Format yang Didukung";
-"Discard Changes" = "Buang Perubahan";
-"Discard" = "Buang";
+"Discard Changes" = "Buanglah Perubahan";
+"Discard" = "Buanglah";
 
 "Menu" = "Menu";
 "Back" = "Kembali";
 
 "Contact" = "Kontak";
-"Open From..." = "Buka Dari...";
+"Open From..." = "Buka dari..."; /* `from` or `dari` is conjunction, so in Indonesian must start with a lowercase letter */
 "Import..." = "Impor...";
 "Recent Documents" = "Dokumen Terkini";
-"Search for" = "Cari";
-"Clear Recent Documents" = "Hilangkan Dokumen Terkini";
-"File Name" = "Nama File";
-"Path" = "Path";
-"Export As..." = "Ekspor Sebagai...";
-"More Formats" = "Format Lainnya";
-"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Format file dalam 'Format Lainnya' memerlukan pemasangan <a class='open-pandoc-guide'>Pandoc</a>.";
-"Something is Wrong…" = "Ada Kesalahan…";
-"Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control//'>Recover lost contents</a></li></ul>" = "Penyimpanan konten gagal dengan sejumlah alasan.<br/>Anda dapat menyalin konten ke jendela Typora yang baru, kemudian simpan. <br/>Pelajari lebih lanjut tentang:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Laporkan bug ke kami</a></li><li><a href='https://support.typora.io/Version-Control//'>Dapatkan kembali konten yang hilang</a></li></ul>";
-"Copy Content" = "Salin Konten";
+"Search for" = "Cari untuk";
+"Clear Recent Documents" = "Bersihkan Dokumen Terkini";
+"File Name" = "Nama Berkas";
+"Path" = "Jalur";
+"Export As..." = "Ekspor sebagai...";
+"More Formats" = "Format Lain";
+"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Format berkas dalam 'Format Lain' memerlukan <a class='open-pandoc-guide'>Pandoc untuk diinstall</a>.";
+"Something is Wrong…" = "Ada Sesuatu yang Salah……";
+"Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control//'>Recover lost contents</a></li></ul>" = "Penyimpanan konten gagal dengan sejumlah alasan.<br/>Anda dapat menyalin konten ke jendela baru Typora, kemudian simpan. <br/>Pelajari lagi tentang:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Laporkan bug ke kami</a></li><li><a href='https://support.typora.io/Version-Control//'>Pulihkan konten yang hilang</a></li></ul>";
+"Copy Content" = "Kopi Konten";
 
 
 "Total" = "Total";
-"Word count only support OS X later than 10.10." = "Perhitungan kata hanya mendukung OS X lebih baru daripada 10.10.";
-"Indent Size for Code" = "Anjurkan Ukuran untuk Kode";
-"Auto wrap long lines" = "Bungkus baris yang panjang secara otomatis";
+"Word count only support OS X later than 10.10." = "Jumlah kata hanya mendukung OS X lebih baru daripada 10.10.";
+"Indent Size for Code" = "Ukuran Indentasi untuk Kode";
+"Auto wrap long lines" = "Oto bungkus baris panjang";
 
-"Sorry, current version of Typora won't print background color.\nSo dark theme is not yet supported for printing. \n\nPlease choose a light theme or export this document to PDF." = "Maaf, versi Typora saat ini tidak akan mencetak warna latar belakang.\nJadi proses cetak belum mendukung tema gelap. \n\nSilakan pilih mode terang atau ekspor dokumen ini ke PDF.";
+"Sorry, current version of Typora won't print background color.\nSo dark theme is not yet supported for printing. \n\nPlease choose a light theme or export this document to PDF." = "Maaf, Typora versi terkini tidak akan mencetak warna latarbelakang.\nJadi tema gelap belum didukung untuk percetakan. \n\nSilakan pilih mode terang atau ekspor dokumen ini ke PDF.";
 "Export to PDF" = "Ekspor ke PDF";
-"Pretty indentation" = "Penganjuran Cantik";
-"Update markdown reference for this image" = "Perbarui referensi markdown untuk gambar ini";
+"Pretty indentation" = "Indentasi Cantik";
+"Update markdown reference for this image" = "Mutakhirkan referensi markdown untuk gambar ini";
 
-"No special action" = "Tidak ada aksi yang spesial";
-"Copy image to current folder (./)" = "Salin gambar ke folder saat ini (./)";
-"Copy image to ./assets" = "Salin gambar ke ./assets";
-"Copy image to ./${filename}.assets" = "Salin gambar ke ./${filename}.assets";
-"Upload image via iPic" = "Unggah gambar melalui iPic";
+"No special action" = "Tiada aksi spesial";
+"Copy image to current folder (./)" = "Kopi gambar ke folder saat ini (./)";
+"Copy image to ./assets" = "Kopi gambar ke ./assets";
+"Copy image to ./${filename}.assets" = "Kopi gambar ke ./${filename}.assets";
+"Upload image via iPic" = "Unggah gambar via iPic";
 "Apply above rules to local images" = "Terapkan aturan di atas untuk gambar lokal";
 "Apply above rules to online images" = "Terapkan aturan di atas untuk gambar daring";
-"Allow upload images automatically based on YAML settings" = "Perbolehkan unggahan gambar secara otomatis berdasarkan pengaturan YAML";
+"Allow upload images automatically based on YAML settings" = "Izinkan unggah gambar secara otomatis berdasarkan pengaturan YAML";
 
-"Learn More" = "Pelajari Lebih Lanjut";
-"Whitespace / Line Break" = "Spasi Putih / Pembatas Baris";
+"Learn More" = "Pelajari Lagi";
+"Whitespace / Line Break" = "Spasiputih / Jeda Baris";
 "When Writing" = "Ketika Menulis";
 "Export / Print" = "Ekspor / Cetak";
-"Preserve sequential whitespace and single line break" = "Pertahankan spasi putih dan pembatas garis tunggal";
-"Ignore sequential whitespace and single line break" = "Acuhkan spasi putih dan pembatas garis tunggal";
+"Preserve sequential whitespace and single line break" = "Pertahankan spasiputih sekuensial dan jeda baris tunggal";
+"Ignore sequential whitespace and single line break" = "Abaikan spasiputih sekuensial dan jeda baris tunggal";
 
 "Quit" = "Keluar";
-"Quit Typora when last window is closed" = "Keluar Typora ketika jendela terakhir ditutup";
+"Quit Typora when last window is closed" = "Keluarkan Typora ketika jendela terakhir ditutup";
 "On Launch" = "Sedang Diluncurkan";
-"Open new file" = "Buka file baru";
-"Restore last closed folders" = "Kembalikan folder yang terakhir ditutup";
-"Restore last closed files and folders" = "Kembalikan file dan folder yang terakhir ditutup";
-"Open custom folder" = "Buka folder khusus";
-"Select custom folder" = "Pilih folder khusus";
+"Open new file" = "Buka berkas baru";
+"Restore last closed folders" = "Pulihkan folder yang ditutup terakhir";
+"Restore last closed files and folders" = "Pulihkan berkas dan folder yang ditutup terakhir";
+"Open custom folder" = "Buka folder kostum";
+"Select custom folder" = "Seleksi folder kostum";
 "This option may be overridden by \"Close windows when quitting an application\" in System Preferences" = "Opsi ini mungkin akan ditimpa oleh \"Tutup jendela ketika keluar dari aplikasi\" di Preferensi Sistem";
 
 "Ignore" = "Abaikan";
-"Choose Default Folder" = "Pilih Folder Standar";
-"<div><strong>Convert on Input</strong>: Input ASCII dashes or quotes, converted and saved as curly quotes or unicode dashes.<br/><strong>Convert on Rendering</strong>: Input and saved as ASCII dashes or quotes, render as curly quotes or unicode dashes.</div>" = "<div><strong>Konversi saat Masukan</strong>: Masukkan garis hubung atau kutipan ASCII, konversi dan simpan sebagai kutipan keriting atau garis hubung unicode.<br/><strong>Konversi saat Rendering</strong>: Masukkan dan simpan sebagai garis hubung atau kutipan ASCII, render sebagai kutipan keriting atau garis hubung unicode.</div>";
-"<div>Recognize unicode punctuations as ASCII ones when parse markdown, e.g:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>It will be turned on automatically if smart quotes/dashes will be converted on input.<div>" = "<div>Kenali tanda baca unicode sebagai ASCII ketika menguraikan markdown, contoh:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>Ini akan diaktifkan secara otomatis jika kutipan/tanda hubung cerdas akan dikonversi saat masukan.<div>";
+"Choose Default Folder" = "Pilih Folder Asali";
+"<div><strong>Convert on Input</strong>: Input ASCII dashes or quotes, converted and saved as curly quotes or unicode dashes.<br/><strong>Convert on Rendering</strong>: Input and saved as ASCII dashes or quotes, render as curly quotes or unicode dashes.</div>" = "<div><strong>Konversi saat Input</strong>: Input tanda hubung atau kutipan ASCII, konversi dan simpan sebagai kutipan keriting atau tanda hubung unikode.<br/><strong>Konversi saat Renderisasi</strong>: Input dan simpan sebagai tanda hubung atau kutipan ASCII, render sebagai kutipan keriting atau tanda hubung unikode.</div>";
+"<div>Recognize unicode punctuations as ASCII ones when parse markdown, e.g:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>It will be turned on automatically if smart quotes/dashes will be converted on input.<div>" = "<div>Rekognisikan pungtuasi unikode sebagai ASCII ketika menguraikan markdown, contoh:<br/> <pre> 》 blockquote → > blockquote <br/> [link](src ’title’) → [link](src 'title')</pre>Ini akan diaktifkan secara otomatis jika kutipan/tanda hubung cerdas akan dikonversi pada input.<div>";
 
-"Copy image to custom folder" = "Salin gambar ke folder khusus";
-"Please specify a relative path to current folder which begins with './' or '../', or an absolute folder path. (`${filename}` representing for currents filename.)" = "Mohon tentukan path relatif ke folder saat ini (dimulai dengan './' or '../') atau path folder absolut. (`${filename}` mewakili nama file saat ini.)";
-"Restore to previous setting" = "Kembalikan ke pengaturan sebelumnya";
-"Folder not exist at %@, please input another path." = "Folder tidak ada di %@, mohon masukkan path lain.";
-"Please input a folder path." = "Mohon masukkan path folder.";
-"Cannot use root path." = "Tidak dapat menggunakan path asal.";
+"Copy image to custom folder" = "Kopi gambar ke folder kostum";
+"Please specify a relative path to current folder which begins with './' or '../', or an absolute folder path. (`${filename}` representing for currents filename.)" = "Mohon spesifikasikan jalur relatif ke folder saat ini (dimulai dengan './' or '../') atau jalur folder absolut. (`${filename}` mewakili nama berkas saat ini.)";
+"Restore to previous setting" = "Pulihkan ke pengaturan sebelumnya";
+"Folder not exist at %@, please input another path." = "Folder tidak eksis di %@, mohon input jalur lain.";
+"Please input a folder path." = "Mohon input jalur folder.";
+"Cannot use root path." = "Takdapat menggunakan jalur akar.";
 
-"Get Themes" = "Dapatkan tema";
-"File/directory already exists at target path." = "File/folder sudah ada di path tujuan.";
+"Get Themes" = "Dapatkan Tema";
+"File/directory already exists at target path." = "Berkas/direktori sudah eksis di jalur target.";
 "Keep Both" = "Simpan Keduanya";
-"Are you sure you want to move %@?" = "Apakah Anda yakin ingin memindahkan %@?";
+"Are you sure you want to move %@?" = "Apakah Anda yakin Anda ingin memindahkan %@?";
 
-"Are you sure you want to delete %@?" = "Apakah Anda yakin ingin menghapus %@?";
-"You can restore from the Trash." = "Anda dapat mengembalikannya dari Tempat Sampah.";
+"Are you sure you want to delete %@?" = "Apakah Anda yakin Anda ingin menghapus %@?";
+"You can restore from the Trash." = "Anda dapat memulihkan dari Tongsampah.";
 
-"Reset All Dialog Warnings" = "Atur Ulang Semua Peringatan Dialog";
+"Reset All Dialog Warnings" = "Reset Semua Peringatan Dialog";
 "Dialogs" = "Dialog";
-"Dialog warnings have been reset." = "Peringatan dialog telah diatur ulang.";
+"Dialog warnings have been reset." = "Peringatan dialog telah direset.";
 
 "Operation Failed" = "Operasi Gagal";
-"Failed to move target file or folder to trash" = "Gagal memindahkan file atau folder tujuan ke tempat sampah";
+"Failed to move target file or folder to trash" = "Gagal memindahkan berkas atau folder tujuan ke tongsampah";
 
-"Undo %@" = "Kembalikan %@";
+"Undo %@" = "Takjadi %@";
 "Rename %@" = "Ubah Nama %@";
-"Copy %@" = "Salin %@";
+"Copy %@" = "Kopi %@";
 "Move %@" = "Pindahkan %@";
 "Delete %@" = "Hapus %@";

--- a/id-ID.lproj/Panel.strings
+++ b/id-ID.lproj/Panel.strings
@@ -1,8 +1,7 @@
 /*
-
  Panel.strings
  translations for preference panel and other dialogs
-
+ 
  by hi@typora.io
 
  Indonesian (Bahasa Indonesia) Translation
@@ -19,7 +18,6 @@
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
   Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
-
 */
 
 /* Preference Panel */
@@ -41,8 +39,8 @@
 "Customized" = "Dikostumisasi";
 "If custom font size is used, the actual font size will depend on the base font size and css style." = "Jika ukuran fon kustom digunakan, ukuran fon aktual akan bergantung pada ukuran fon dan gaya css dasar.";
 "Left Panel" = "Panel Kiri";
-"Show Outline Panel by Default" = "Tampilkan Panel Ikhtisar sebagai Asali"; /* See <https://kbbi.kemdikbud.go.id/entri/asali> */
-"Collapsible Outline on Left Panel" = "Ikhtisar yang dapat dilipat pada Panel Kiri";
+"Show Outline Panel by Default" = "Munculkan Panel Garisbesar sebagai Asali"; /* See <https://kbbi.kemdikbud.go.id/entri/asali> */
+"Collapsible Outline on Left Panel" = "Garisbesar Kolapsibel pada Panel Kiri";
 "Save without asking when\nswitch files on side panel" = "Simpan tanpa pertanyaan ketika\nberalih fail pada panel sisi"; /* `Fail` is more accurate than `berkas`, but see <https://kbbi.kemdikbud.go.id/entri/fail> */
 "Language" = "Bahasa";
 "System Language" = "Bahasa Sistem";
@@ -69,10 +67,10 @@
 "Markdown" = "Markdown";
 "(Following preferences will be applied after restart.)" = "(Preferensi berikut akan diterapkan setelah kembali mulai.)";
 "Syntax Support" = "Bantuan Sintaksis";
-"Inline Math  ( e.g: $\LaTeX$ )" = "Matematika Sebaris  ( e.g: $\LaTeX$ )";
-"Subscript    ( e.g: H~2~O )" = "Subskrip    ( e.g: H~2~O )";
-"Superscript ( e.g: X^2^ )" = "Superskrip ( e.g: X^2^ )";
-"Highlight     (e.g: ==key==)" = "Sorotan     (e.g: ==key==)";
+"Inline Math  ( e.g: $\LaTeX$ )" = "Matematika Sebaris  ( contoh: $\LaTeX$ )";
+"Subscript    ( e.g: H~2~O )" = "Subskrip    ( contoh: H~2~O )";
+"Superscript ( e.g: X^2^ )" = "Superskrip ( contoh: X^2^ )";
+"Highlight     (e.g: ==key==)" = "Sorotan     (contoh: ==key==)";
 "Diagrams" = "Diagram";
 "(Sequence, Flowchart and Mermaid)" = "(Sekuens, Diagram Alir dan Mermaid)"; /* See <https://id.wikipedia.org/wiki/Diagram_alir> */
 "Syntax Preference" = "Preferensi Sintaksis";
@@ -123,7 +121,7 @@
 "Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "Apakah Anda ingin menyimpan perubahan yang dibuat pada dokumen ini ?<br> Perubahan Anda akan hilang jika Anda tidak menyimpannya.";
 "[Warning] Failed to attach bookmark for PDF file." = "[Peringatan] Gagal melampirkan markahbuku untuk fail PDF."; /* See <https://kbbi.kemdikbud.go.id/entri/markah> and <https://kbbi.kemdikbud.go.id/entri/buku> */
 "Dark Theme not support" = "Tema Gelap tidak mendukung";
-"Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Maaf, versi Typora saat ini tidak akan mencetak warna latarbelakang pada PDF yang diekspor, jadi proses ekspor PDF belum mendukung tema gelap. \nSila pilihlah mode terang atau pilih \"Cetak dengan tema asali\"";
+"Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Maaf, versi Typora saat ini tidak akan mencetak warna latarbelakang pada PDF yang diekspor, jadi proses ekspor PDF belum mendukung tema gelap. \nSilakan pilihlah mode terang atau pilih \"Cetak dengan tema asali\"";
 "Print with default theme" = "Cetak dengan tema asali";
 "Export to PDF successfully." = "Ekspor ke PDF sukses secara penuh.";
 "Converting file using Pandoc. This may take some time." = "Konversi fail menggunakan Pandoc. Ini mungkin memakan beberapa waktu.";
@@ -166,7 +164,7 @@
 "Auto correct spelling" = "Oto koreksi ejaan";
 "System" = "Sistem";
 "Privacy" = "Privasi";
-"Developer" = "Pengembang";
+"Developer" = "Developer"; /* See <https://kbbi.kemdikbud.go.id/entri/developer> */
 "Update" = "Pemutakhiran";
 "Check Updates" = "Cek Pemutakhiran";
 "Check updates automatically" = "Cek Pemutakhiran secara otomatis";
@@ -181,14 +179,14 @@
 "This feature require macOS >= 10.11" = "Fitur ini memerlukan macOS >= 10.11";
 "One More Step" = "Satu Step Lagi"; /* See <https://kbbi.kemdikbud.go.id/entri/step> */
 "Notice" = "Maklumat"; /* See <https://kbbi.kemdikbud.go.id/entri/maklumat> */
-"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan iPic untuk diinstal, dan fail gambar yang diacu akan diunggah ke layanan awan via iPic. Mohon juga catat bahwa layanan awan bawaan tidak mendukung penghapusan gambar yang diunggah.";
+"This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Ini memerlukan iPic untuk diinstal, dan fail gambar yang diacu akan diunggah ke layanan awan via iPic. Silakan juga catat bahwa layanan awan bawaan tidak mendukung penghapusan gambar yang diunggah.";
 
 "%d Images Failed to Upload." = "%d Gambar Gagal Diunggah.";
 "%d Succeeded," = "%d Sukses, ";
 "Enable this feature on preferences panel" = "Aktifkan fitur ini pada panel preferensi";
 "%@ is a file, not a directory" = "%@ adalah sebuah fail, bukan folder";
 "Copy Images To…" = "Kopi Gambar ke…";
-"Typora are trying copy the newly inserted image to folder %@ according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru dimasukkan ke folder %@ sesuai dengan pengaturan YAML Front Matter atau preferensi global Anda. Namun, terget folder tidak eksis. Buat folder tersebut sekarang?";
+"Typora are trying copy the newly inserted image to folder %@ according to your YAML Front Matter setting or global preferences. But the target folder does not exist, create it now?" = "Typora mencoba menyalin gambar yang baru dimasukkan ke folder %@ sesuai dengan setelan YAML Front Matter atau preferensi global Anda. Namun, terget folder tidak eksis. Buat folder tersebut sekarang?";
 "Create Folder and Continue" = "Buat Folder dan Lanjutkan";
 "Document must be saved first" = "Dokumen harus disimpan dahulu";
 "Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora akan mengopi gambar yang baru dimasukkan ke folder dengan jalur relatif yang diseleksi, jadi mohon simpan fail tersebut dahulu.";
@@ -239,7 +237,7 @@
 "Upload image via iPic" = "Unggah gambar via iPic";
 "Apply above rules to local images" = "Terapkan aturan di atas untuk gambar lokal";
 "Apply above rules to online images" = "Terapkan aturan di atas untuk gambar daring";
-"Allow upload images automatically based on YAML settings" = "Izinkan unggah gambar secara otomatis berdasarkan pengaturan YAML";
+"Allow upload images automatically based on YAML settings" = "Izinkan unggah gambar secara otomatis berdasarkan setelan YAML";
 
 "Learn More" = "Pelajari Lagi";
 "Whitespace / Line Break" = "Spasiputih / Jeda Baris";
@@ -265,7 +263,7 @@
 
 "Copy image to custom folder" = "Kopi gambar ke folder kostum";
 "Please specify a relative path to current folder which begins with './' or '../', or an absolute folder path. (`${filename}` representing for currents filename.)" = "Mohon spesifikasikan jalur relatif ke folder saat ini (dimulai dengan './' or '../') atau jalur folder absolut. (`${filename}` mewakili nama fail saat ini.)";
-"Restore to previous setting" = "Pulihkan ke pengaturan sebelumnya";
+"Restore to previous setting" = "Pulihkan ke setelan sebelumnya";
 "Folder not exist at %@, please input another path." = "Folder tidak eksis di %@, mohon input jalur lain.";
 "Please input a folder path." = "Mohon input jalur folder.";
 "Cannot use root path." = "Takdapat menggunakan jalur akar.";
@@ -286,7 +284,221 @@
 "Failed to move target file or folder to trash" = "Gagal memindahkan fail atau folder tujuan ke tongsampah";
 
 "Undo %@" = "Takjadi %@";
-"Rename %@" = "Ubah Nama %@";
+"Rename %@" = "Namaiulang %@";
 "Copy %@" = "Kopi %@";
 "Move %@" = "Pindahkan %@";
 "Delete %@" = "Hapus %@";
+
+"Turn off Typewriter / Focus Mode" = "Matikan Mode Mesin Tik / Fokus";
+"Typewriter / Focus Mode have been turned off." = "Mode Mesin Tik / Fokus telah dimatikan.";
+
+"Reading Speed" = "Kecepatan Membaca";
+"Auto" = "Oto";
+"words / min" = "kata / men";
+
+"Reset to Default" = "Reset ke Asali";
+"120  words/minute (Slow)" = "120  kata/menit (Lambat)";
+"240  words/minute (Medium)" = "240  kata/menit (Medium)";
+"382  words/minute (Fast)" = "382  kata/menit (Cepat)";
+
+"Copy and update image source to…" = "Kopi dan mutakhirkan sumber gambar ke…";
+"Updater" = "Pemutakhir";
+"Install Updates ?" = "Instal Pemutakhiran ?";
+"Quit and Install" = "keluar and Instal";
+"Download failed" = "Unduhan gagal";
+"Downloading Updates…" = "Mengunduh Pemutakhiran…";
+"Checking Updates…" = "Cek Pemutakhiran…";
+"Check Update Failed" = "Cek Pemutakhiran Gagal";
+"You're up to date!" = "Anda mutakhir!";
+"Latest version is $1, your version is $2" = "Versi terbaru adalah $1, versi Anda adalah $2";
+"These options can also be changed under \"Edit→Whitespace and Line Breaks\" menu" = "Opsi ini juga dapat diubah di bawah \"Edit→Spasiputih dan Jeda Baris\" menu";
+"Auto escape image URL when insert" = "Oto loloskan URL Gambar saat penyisipan";
+"For example, if you insert a file at 'img/example file.png', it will become 'img/example%20file.png'. Enable this for better compatibility with other Markdown engines, or disable this for better readability." = "Sebagai contoh, jika Anda memasukkan fail di 'img/example file.png', itu akan menjadi 'img/example%20file.png'. Aktifkan ini untuk kompatibilitas yang lebih baik dengan mesin Markdown lainnya, atau nonaktifkan ini untuk keterbacaan yang lebih baik.";
+"Check updates automatically" = "Cek Pemutakhiran secara otomatis";
+"Skip This Version" = "Lewati Versi Ini";
+"Remind Me Later" = "Ingatkan Saya Nanti";
+"Download Update" = "Unduh Pemutakhiran";
+"New version available." = "Versi baru tersedia.";
+
+"When copy / export as HTML (without style)" = "Ketika kopi / ekspor sebagai HTML (tanpa gaya)";
+"Use Rendered SVG" = "Gunakan Perenderan SVG";
+"Use LaTeX Source" = "Gunakan Sumber LaTeX";
+"<div>Take effects when export as HTML (without styles) or copy as HTML code, or copy without theme style.<br/>When <strong>Use LaTeX Source</strong> is selected, Typora will put the raw LaTeX source (e.g: $X^2$),<br/>When <strong>Use Rendered SVG</strong> is selected, the rendered SVG will be used, if you paste to other app, SVG may get ignored.</div>" = "<div>Ambil efek saat mengekspor sebagai HTML (tanpa gaya) atau mengopi sebagai kode HTML, atau mengopi tanpa gaya tema.<br/>Ketika <strong>Gunakan Sumber LaTeX</strong> diseleksi, Typora akan menempatkan sumber LaTeX mentah (contoh: $X^2$),<br/>Ketika <strong>Gunakan Perenderan SVG</strong> diseleksi, SVG yang dirender akan digunakan, jika Anda menempelkan ke aplikasi lain, SVG mungkin akan diabaikan.</div>";
+
+"Import function and several export formats requires Pandoc (≥%@) to be installed." = "Fungsi impor dan beberapa format ekspor memerlukan Pandoc (≥%@) untuk diinstall.";
+"Do not show this message again" = "Jangan tampilkan pesan ini lagi";
+
+"Page Break Between Top Headings" = "Pemisahan Halaman di Antara Tajuk Teratas";
+
+"Sorry, some error happened, current writing content has been copied to clipboard. You could report this to <hi@typora.io> to help us fix this error." = "Maaf, terjadi kesalahan, konten tulisan saat ini telah disalin ke papan klip. Anda dapat melaporkan ini ke <hi@typora.io> untuk membantu kami memperbaiki eror ini.";
+"Try Recovery" = "Coba Pemulihan";
+"Other Options for Data Recovery" = "Opsi Lain untuk Pemulihan Data";
+
+"When Insert" = "Ketika Menyisipkan";
+"Upload image" = "Unggah gambar";
+"e.g: %@" = "contoh: %@";
+"Test Uploader" = "Tes Pengunggah";
+"Validating" = "Memvalidasi";
+"Validation Failed" = "Validasi Gagal";
+"Validation Succeed" = "Validasi Sukses";
+"Testing image uploading using command:" = "Mengetes pengunggahan gambar menggunakan perintah:";
+"Running… Waiting for results." = "Menjalankan… Menunggu hasil.";
+"Output from the console:" = "Keluaran dari konsol:";
+"Error from the console:" = "Eror dari konsol:";
+"Failed to fetch uploaded image from command output." = "Gagal mengambil gambar yang diunggah dari keluaran perintah.";
+"Successfully get uploaded image url." = "Sukses penuh mendapatkan url gambar yang diunggah.";
+"Image Uploader" = "Pengunggah Gambar";
+"Instructions" = "Instruksi";
+"Download %@" = "Unduh %@";
+"Image Upload Setting" = "Setelan Penggunggah Gambar";
+"Please set an image uploader in Preferences panel before using this function." = "Silakan setel pengunggah gambar di panel Preferensi sebelum menggunakan fungsi ini.";
+"Download or Upgrade" = "Unduh atau Tingkatkan";
+"Open Config File" = "Buka Konfigurasi Fail";
+"Command" = "Perintah";
+"PicGo Path" = "Jalur PicGo";
+"Path of PicGo binary" = "Jalur dari binari PicGo";
+"Executable" = "Eksekutabel";
+"Checking" = "Mengecek";
+"Download" = "Unduh";
+"Agree and Download" = "Setuju dan Unduh";
+"Download and Reinstall" = "Unduh dan Kembali Instal";
+"Loading PicGo-Core License" = "Memuat Lisensi PicGo-Core";
+"Failed to get installed version of PicGo-Core (command line)" = "Gagal menginstal versi PicGo-Core (baris perintah)";
+"You have the latest PicGo-Core (CLI)" = "Anda memiliki yang terbaru PicGo-Core (Antarmuka Baris Perintah)";
+"Newer version is available" = "Versi yang lebih baru tersedia";
+
+"Downloading…" = "Mengunduh…";
+"Unzipping…" = "Pengunzipan…";
+"Finished" = "Finis";
+
+"Typora will launch 3rd party app with file paths of all local images. The image uploader and cloud image storage will then have access to your local images. Are you sure to continue?" = "Typora akan meluncurkan aplikasi pihak ke-3 dengan jalur fail dari semua gambar lokal. Pengunggah gambar dan penyimpanan gambar awan kemudian akan memiliki akses ke gambar lokal Anda. Apakah Anda yakin untuk melanjutkan?";
+
+"Export operation finished successfully." = "Operasi ekspor berhasil disukseskan penuh.";
+
+"Shortcut Keys" = "Kunci Pintasan";
+"Custom Shortcut Keys" = "Kunci Pintasan Kustom";
+
+"Theme" = "Tema";
+"Light Theme" = "Tema Terang";
+"Dark Theme" = "Tema Gelap";
+"Use separate theme in dark mode" = "Gunakan tema terpisah dalam mode gelap";
+"Supported on macOS ≥ 10.15 or Windows 10 ≥ 1903" = "Didukung di macOS ≥ 10.15 atau Windows 10 ≥ 1903";
+"Convert -- to – (en dash), and --- to — (em dash)" = "Konversi -- ke – (en dash), dan --- ke — (em dash)";
+"Convert -- and --- to — (em dash)" = "Konversi -- dan --- ke — (em dash)";
+"You could set quote patterns in System Preferences → Keyboard → Text. If it is changed, Typora will need a restart to apply it." = "Anda dapat mengatur pola kutipan di Preferensi Sistem → Papanketik → Teks. Jika diubah, Typora perlu memulai ulang untuk menerapkannya.";
+
+
+"Paper Size" = "Ukuran Kertas";
+"US Letter" = "Letter US";
+"US Legal" = "Legal US";
+"Tabloid" = "Tabloid";
+"Page Break" = "Pemisahan Halaman";
+"Page Break Between Top Headings" = "Pemisahan Halaman di Antara Tajuk Teratas";
+"Header" = "Header";
+"Footer" = "Footer";
+"Author" = "Pengarang";
+"Append in <head />" = "Tambahkan di <head />";
+"Append in <body />" = "Tambahkan di <body />";
+"Include Outline Sidebar" = "Sertakan Bilahsisi Garisbesar";
+"Width" = "Lebar";
+"Command" = "Perintah";
+"Show Save File Dialog" = "Munculkan Dialog Simpan Fail";
+"File Extensions for Export" = "Ekstensi Fail untuk Ekspor";
+"Arguments" = "Argumen";
+"Extra Arguments" = "Argumen Ekstra";
+"LaTeX Engine" = "Mesin LaTeX";
+"Template" = "Templat";
+"Empty" = "Kosong";
+"Style Reference" = "Referensi Gaya";
+"Custom CSS" = "CSS Kustom";
+"Chapter Level" = "Level Bab";
+"Default Folder for Exported File" = "Folder Asali untuk Fail Terekspor";
+"Same folder with current file" = "Folder sama dengan fail saat ini";
+"Custom location" = "Lokasi kustom";
+"(Auto Detect)" = "(Oto Deteksi)";
+"After Export" = "Setelah Ekspor";
+"Open exported file location" = "Buka lokasi fail terekspor";
+"Open exported file" = "Buka fail terekspor";
+"Custom" = "Kustom";
+"None" = "Tiada";
+"Default" = "Asali";
+"Margin" = "Margin";
+"Margin Left" = "Margin Kiri";
+"Margin Right" = "Margin Kanan";
+"Margin Top" = "Margin Atas";
+"Margin Bottom" = "Margin Bawah";
+"Width x Height" = "Lebar x Tinggi";
+"Add From a Template" = "Tambahkan dari sebuah Templat";
+"Delete this export option ?" = "Hapus opsi ekspor ini ?";
+"Add" = "Tambahkan";
+"Delete" = "Hapus";
+"Rename" = "Namaiulang";
+"Move Down" = "Turunkan";
+"Move Up" = "Naikkan";
+"Pandoc Path" = "Jalur Pandoc";
+"Select" = "Seleksi";
+"Target Format" = "Format Target";
+"auto detect based on target file path" = "oto deteksi berdasarkan jalur fail target";
+"Target File Extensions (separate by whitespace)" = "Ekstensi Fail Target (pisahkan dengan spasiputih)";
+"e.g: .text .asciidoc or leave this empty" = "contoh: .text .asciidoc atau biarkan ini kosong";
+"Raw Type" = "Tipe Mentah";
+"Auto" = "Oto";
+"Show Save File Dialog" = "Munculkan Dialog Simpan Fail";
+"Do not popup save file dialog" = "Jangan munculkan dialog simpan fail";
+"Select file path to save" = "Seleksi jalur fail untuk menyimpan";
+"Select folder path to save" = "Seleksi jalur folder untuk menyimpan";
+"PDF Engine" = "Mesin PDF";
+"Show command output" = "Munculkan Keluaran Perintah";
+
+"\"Export and Overwrite with Previous\" will overwrite file at %@, would you continue?" = "\"Ekspor dan Timpa dengan Sebelumnya\" akan menimpa file di %@, sediakah Anda melanjutkan?";
+"Command Arguments:" = "Argumen Perintah:";
+"This beta version of Typora is expired, please download and install a newer version." = "Typora versi beta ini kedaluwarsa, silakan unduh dan instal versi yang lebih baru.";
+"Current Theme" = "Tema Saat Ini";
+"After Export" = "Setelah Ekspor";
+"Run command" = "Jalankan perintah";
+"Run command after export failed" = "Jalankan perintah setelah ekspor gagal";
+"Read and overwrite export settings from YAML front matters" = "Baca dan timpa pengaturan ekspor dari YAML Front Matter";
+"Append Extra Content (HTML)" = "Tambahkan Konten Ekstra (HTML)";
+"Change this option to specify a separated theme for export." = "Ubah opsi ini untuk menentukan tema terpisah untuk ekspor.";
+"Dark theme is not supported." = "Tema gelap tidak didukung.";
+
+"Markdown Variants" = "Varian Markdown";
+"Original Unextended Markdown" = "Markdown Orisinal Takdiperpanjang";
+"CommonMark with many pandoc extensions" = "CommonMark dengan banyak ekstensi pandoc";
+"Line Wrap" = "Bungkus Garis";
+"Hard line wrap" = "Bungkus garis keras";
+"Text Column Width" = "Lebar Kolom Teks";
+"Auto (based on current OS)" = "Oto (berdasarkan OS saat ini)";
+"Indent" = "Indentasi";
+"Preserve tabs" = "Pertahankan tab";
+"2 spaces per tab" = "2 spasi per tab";
+"3 spaces per tab" = "3 spasi per tab";
+"4 spaces per tab" = "4 spasi per tab";
+"Unicode Characters" = "Karakter Unikode";
+"Use only ASCII characters in output" = "Gunakan hanya karakter ASCII di keluaran";
+"Use reference-style links rather than inline links" = "Gunakan tautan gaya-referensi daripada tautan sebaris";
+"Footnotes and References Location" = "Catatan Kaki dan Lokasi Referensi";
+"End of document" = "Akhir dari dokumen";
+"End of current (top-level) block" = "Akhir dari blok (tingkat-atas) saat ini";
+"End of current section" = "Akhir seksi saat ini";
+"Convert TeX formulas to web images" = "Konversi formula TeX ke gambar web";
+"Image Format" = "Format Gambar";
+
+"Set Pandoc Path" = "Setel Jalur Pandoc";
+
+"Apply Line Break at \\ and &#92;newline" = "Terapkan Jeda Baris di \\ dan &#92;barisbaru";
+
+"Export operation succeeded with warnings." = "Operasi Ekspor sukses dengan peringatan.";
+
+"Typora is now deactivated" = "Typora terdeaktivasi sekarang";
+"This device has been deactivated" = "Perangkat ini telah terdeaktivasi";
+"UNREGISTERED" = "TAKTERDAFTAR";
+
+"Allow physics package to redefine existing TeX commands" = "Izinkan paket fisika untuk mendefinisikan kembali perintah TeX yang ada";
+"When enabled, commands like \\div, \\Re will be redefined by physics package." = "Saat diaktifkan, perintah seperti \\div, \\Re akan didefinisikan ulang oleh paket fisika.";
+
+"Your Typora is not activated." = "Typora Anda tidak diaktifkan.";
+"Your Typora has been activated." = "Typora Anda telah diaktifkan.";
+"Typora activation is required to change this." = "Aktivasi Typora diperlukan untuk mengubah ini.";
+"You can reinstall the stable version and then disable this." = "Anda dapat menginstalulang versi stabil dan kemudian menonaktifkan ini.";
+"Update to dev version" = "Perbarui ke versi developer";

--- a/id-ID.lproj/Panel.strings
+++ b/id-ID.lproj/Panel.strings
@@ -18,7 +18,7 @@
 
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
-  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
 
 */
 

--- a/id-ID.lproj/Panel.strings
+++ b/id-ID.lproj/Panel.strings
@@ -35,7 +35,7 @@
 "Open Theme Folder" = "Buka Folder Tema";
 "Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Silakan cek `bantuan`->`Mulai Segera` untuk introduksi pendek. Kunjungi http://theme.typora.io untuk mendapatkan lebih banyak tema atau instruksi.";
 "Word Count" = "Jumlah Kata";
-"Always Show Word Count" = "Selalu Tampilkan Jumlah Kata";
+"Always Show Word Count" = "Selalu Munculkan Jumlah Kata";
 "Font Size" = "Ukuran Fon"; /* See <https://kbbi.kemdikbud.go.id/entri/fon> */
 "Auto ( Recommended )" = "Oto ( Direkomendasikan )";
 "Customized" = "Dikostumisasi";
@@ -50,7 +50,7 @@
 /* Editor Panel */
 "Editor" = "Editor";
 "Indent Size on Save" = "Ukuran indentasi saat Menyimpan";
-"only apply to quotes and lists created from menu bar or hybrid view" = "hanya terapkah untuk kutipan dan lis yang dibuat dari bilah menu atau tampilan hibrida";
+"only apply to quotes and lists created from menu bar or hybrid view" = "hanya terapkah untuk kutipan dan lis yang dibuat dari bilah menu atau tinjauan hibrida";
 "Trigger Autocomplete without ESC key for" = "Picu Otokomplet tanpa kunci ESC untuk"; /* `Otokomplet` is standard word `autocomplete` */
 "Emoji (e.g. :smile:)" = "Emoji (contoh: :smile:)";
 "Images Insert" = "Penyisipan Gambar";
@@ -76,7 +76,7 @@
 "Diagrams" = "Diagram";
 "(Sequence, Flowchart and Mermaid)" = "(Sekuens, Diagram Alir dan Mermaid)"; /* See <https://id.wikipedia.org/wiki/Diagram_alir> */
 "Syntax Preference" = "Preferensi Sintaksis";
-"(only applies to styles created from menubar or hybrid view)" = "(hanya terapkan terhadap gaya yang dibuat dari bilah menu atau tampilan hibrida)";
+"(only applies to styles created from menubar or hybrid view)" = "(hanya terapkan terhadap gaya yang dibuat dari bilah menu atau tinjauan hibrida)";
 "Strict Mode" = "Mode Ketat";
 "(more strict to GFM spec)" = "(lebih ketat ke spesifikasi GFM)";
 "Heading Style" = "Gaya Tajuk";
@@ -132,7 +132,7 @@
 /* Upload via iPic */
 "Uploading Images via iPic..." = "Pengunggahan Gambar via iPic...";
 "Uploading in progress…" = "Pengunggahan dalam progres...";
-"Do not show this again" = "Jangan tampilkan ini kembali";
+"Do not show this again" = "Jangan munculkan ini kembali";
 
 /* Word Count */
 "Minute" = "Menit";
@@ -153,7 +153,7 @@
 "Unibody" = "Unibodi"; /* Combined words, see <https://kbbi.kemdikbud.go.id/entri/uni> and <https://kbbi.kemdikbud.go.id/entri/bodi> */
 "(applied after restart)" = "(diterapkan setelah kembali mulai)";
 "Status Bar" = "Bilah Status";
-"Show status bar" = "Munculkan bilah status"; /* to differentiate `show` (muncul) and `view` (tampil) */
+"Show status bar" = "Munculkan bilah status";
 "Save & Recover" = "Simpan & Pulihkan";
 "Auto Save" = "Oto Simpan";
 "Recover Unsaved Drafts" = "Pulihkan Draf yang Taktersimpan";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -26,7 +26,7 @@
  */
 
 "Welcome to Typora" = "Selamat Datang di Typora";
-"Thank you for using Typora 👋. Typora is a minimal markdown editor and markdown reader, it gives you a seamless experience between rendered rich style contents and its source code." = "Terima kasih telah menggunakan Typora 👋. Typora adalah editor markdown dan pembaca markdown minimal, yang memberikan Anda pengalaman mulus antara konten gaya kaya yang dirender dan kode sumbernya.";
+"Thank you for using Typora 👋. Typora is a minimal markdown editor and markdown reader, it gives you a seamless experience between rendered rich style contents and its source code." = "Terima kasih telah menggunakan Typora 👋. Typora adalah editor markdown dan pembaca markdown minimal, ia memberi Anda pengalaman mulus antara konten gaya kaya yang dirender dan kode sumbernya.";
 
 "Get Start" = "Mari Mulai"; /* See <https://kbbi.kemdikbud.go.id/entri/mari> */
 "Check following links if you're new to Markdown or Typora." = "Cek pranala berikut jika Anda baru mengenal Markdown atau Typora.";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -49,11 +49,11 @@
 "Code blocks, YAML, tasks, footnotes, tables, math, diagrams" = "Blok kode, YAML, tugas, catatan kaki, tabel, matematika, diagram";
 "Import / Export" = "Impor / Ekspor";
 "Deliver your content in various formats." = "Kirimkan konten Anda dalam berbagai format.";
-"Editing Experience" = "Pengalaman Penyuntingan"; /* See <https://kbbi.kemdikbud.go.id/entri/sunting> */
+"Editing Experience" = "Pengalaman Pengeditan"; /* `Pengeditan` is more accurate than `penyuntingan`, see <https://kbbi.kemdikbud.go.id/entri/pengeditan> */
 "Outline / Word Count / Focus Mode / Typewriter Mode" = "Ikhtisar / Jumlah Kata / Mode Fokus / Mode Mesin Tik";
 
-"Files" = "Berkas"; /* See <https://kbbi.kemdikbud.go.id/entri/berkas> */
-"Manage files in sidebar and search across files." = "Kelola berkas di bilah sisi dan cari di seluruh berkas.";
+"Files" = "Fail"; /* `Fail` is more accurate than `berkas`, see <https://kbbi.kemdikbud.go.id/entri/fail> */
+"Manage files in sidebar and search across files." = "Kelola fail di bilah sisi dan cari di seluruh fail.";
 "Customize" = "Kustomisasi"; /* See <https://id.wikipedia.org/wiki/Wikipedia:Kustomisasi> */
 "Customize your writing experience from preferences panel." = "Kostumisasikan pengalaman menulis Anda melalui panel preferensi.";
 "Themes" = "Tema";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -3,75 +3,90 @@
   Typora
 
  by hi@typora.io
+
+ Indonesian (Bahasa Indonesia) Translation
+ by Samuel Natalius <https://github.com/snatalius> <samnatalius@outlook.com>,
+    Kylamber <https://github.com/Kylamber> <>,
+    Nashrullah Ali Fauzi <https://github.com/nashrullahalifauzi> <nash@nashrullahalifauzi.com>.
+
+  Notice:
+
+  If there is an loanword in the Indonesian dictionary, then use it in Typora. For example, if in English there is the word `font`, then in standard Indonesian it should be written `fon` without the letter `t`, even though there is a non-standard word, `fonta` which has the same meaning.
+
+  Likewise with the word 'input' in English, when it is translated into Indonesian it does not change, because the word 'input' in the Indonesian dictionary, also has the same meaning in English. It is not appropriate to translate the English word 'input' as 'masukan' in Indonesian. This is an attempt to keep the language of the app, especially Typora, from straying too far from its native language as default.
+
+  `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
+
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+
 */
 
 /*
  "Send Anonymous Usage Info"
  */
 
-"Welcome to Typora" = "Selamat datang di Typora";
+"Welcome to Typora" = "Selamat Datang di Typora";
 "Thank you for using Typora 👋. Typora is a minimal markdown editor and markdown reader, it gives you a seamless experience between rendered rich style contents and its source code." = "Terima kasih telah menggunakan Typora 👋. Typora adalah editor markdown dan pembaca markdown minimal, yang memberikan Anda pengalaman mulus antara konten gaya kaya yang dirender dan kode sumbernya.";
 
-"Get Start" = "Memulai";
-"Check following links if you're new to Markdown or Typora." = "Lihat tautan berikut jika Anda baru mengenal Markdown atau Typora.";
+"Get Start" = "Mari Mulai"; /* See <https://kbbi.kemdikbud.go.id/entri/mari> */
+"Check following links if you're new to Markdown or Typora." = "Cek pranala berikut jika Anda baru mengenal Markdown atau Typora.";
 
 "Activate Typora" = "Aktifkan Typora";
-"Already purchased a license? Fill the form below and activate Typora instantly." = "Sudah memiliki lisensi? Isi formulir di bawah ini dan aktifkan Typora secara instan.";
+"Already purchased a license? Fill the form below and activate Typora instantly." = "Sudah membeli lisensi? Isi formulir di bawah ini dan aktifkan Typora secara instan.";
 
-"Email" = "Surel";
-"Email Address" = "Alamat Surel";
+"Email" = "Pos-el"; / Standard word `email` in Indonesian is `pos-el`, see <https://kbbi.kemdikbud.go.id/entri/pos-el> */
+"Email Address" = "Alamat Pos-el";
 "License Code" = "Kode Lisensi";
 
 "Help" = "Bantuan";
-"Find my License" = "Temukan lisensi saya";
+"Find my License" = "Temukan Lisensi Saya";
 
 "Accept <a href='https://support.typora.io/License-Agreement/'>License Agreement</a> and <a href='https://support.typora.io/Privacy-Policy/'>Privacy Policy</a>." = "Terima <a href='https://support.typora.io/License-Agreement/'>Perjanjian Lisensi</a> dan <a href='https://support.typora.io/Privacy-Policy/'>Kebijakan Privasi</a>.";
 
 "Live Preview" = "Pratinjau Langsung";
-"Write and read rendered output instantly." = "Tulis dan baca hasil yang dirender secara instan.";
+"Write and read rendered output instantly." = "Tulis dan baca keluaran yang dirender secara instan.";
 "Markdown Syntax" = "Sintaksis Markdown";
 "Code blocks, YAML, tasks, footnotes, tables, math, diagrams" = "Blok kode, YAML, tugas, catatan kaki, tabel, matematika, diagram";
 "Import / Export" = "Impor / Ekspor";
-"Deliver your content in various formats." = "Kirimkan konten anda dalam berbagai format.";
-"Editing Experience" = "Pengalaman Mengedit";
+"Deliver your content in various formats." = "Kirimkan konten Anda dalam berbagai format.";
+"Editing Experience" = "Pengalaman Penyuntingan"; /* See <https://kbbi.kemdikbud.go.id/entri/sunting> */
 "Outline / Word Count / Focus Mode / Typewriter Mode" = "Ikhtisar / Jumlah Kata / Mode Fokus / Mode Mesin Tik";
 
-"Files" = "File";
-"Manage files in sidebar and search across files." = "Kelola file di bilah sisi dan cari di seluruh file.";
-"Customize" = "Sesuaikan";
-"Customize your writing experience from preferences panel." = "Sesuaikan pengalaman menulis Anda melalui panel preferensi.";
+"Files" = "Berkas"; /* See <https://kbbi.kemdikbud.go.id/entri/berkas> */
+"Manage files in sidebar and search across files." = "Kelola berkas di bilah sisi dan cari di seluruh berkas.";
+"Customize" = "Kustomisasi"; /* See <https://id.wikipedia.org/wiki/Wikipedia:Kustomisasi> */
+"Customize your writing experience from preferences panel." = "Kostumisasikan pengalaman menulis Anda melalui panel preferensi.";
 "Themes" = "Tema";
 "Write in the theme you like, or make one by your own." = "Tulis dalam tema yang Anda suka, atau buat sendiri.";
 "And more" = "Dan lainnya";
-"Explorer more topics at support.typora.io" = "Jelajahi topik lainnya di support.typora.io";
+"Explorer more topics at support.typora.io" = "Eksplorasi topik lainnya di support.typora.io"; /* See <https://kbbi.kemdikbud.go.id/entri/eksplorasi> */
 
-"Quick Start" = "Mulai Cepat";
+"Quick Start" = "Mulai Segera"; /* See <https://kbbi.kemdikbud.go.id/entri/segera> */
 "Markdown Reference" = "Referensi Markdown";
-"Explorer Themes" = "Jelajahi tema";
-"More Topics" = "Topik lainnya";
+"Explorer Themes" = "Eksplorasi Tema";
+"More Topics" = "Topik Lainnya";
 
 "Typora Activated" = "Typora Diaktifkan";
 "Thanks for your purchase." = "Terima kasih atas pembelian Anda.";
 
 "Next" = "Lanjut";
-"Please accept license agreement first" = "Harap terima perjanjian lisensi terlebih dahulu ";
-"Start %@ Days Trail" = "Mulai %@ hari percobaan";
-"Buy License" = "Beli lisensi";
+"Please accept license agreement first" = "Silakan terima perjanjian lisensi dahulu";
+"Start %@ Days Trail" = "Mulai %@ Hari Percobaan";
+"Buy License" = "Beli Lisensi";
 "Activate" = "Aktifkan";
 
 "Close" = "Tutup";
-"Deactivate" = "Nonaktifkan";
-"View License" = "Lihat Lisensi";
+"Deactivate" = "Deaktivasi"; /* See https://kbbi.kemdikbud.go.id/entri/deaktivasi */
+"View License" = "Tampilkan Lisensi";
 "Your Typora License" = "Lisensi Typora Anda";
-"This copy of Typora is registered with license information below." = "Salinan Typora ini terdaftar dengan informasi lisensi di bawah.";
+"This copy of Typora is registered with license information below." = "Kopian atas Typora ini terdaftar dengan informasi lisensi di bawah.";
 "Your trail will be expired in %@ days." = "Percobaan Anda akan berakhir dalam %@ hari.";
 "Enter License" = "Masukkan Lisensi";
 "Not Now" = "Tidak Sekarang";
 
-"Please input a valid email address" = "Harap masukkan alamat email yang valid";
-"Please input a valid license code"  = "Harap masukkan kode lisensi yang valid";
+"Please input a valid email address" = "Silakan masukkan alamat pos-el yang valid";
+"Please input a valid license code"  = "Silakan masukkan kode lisensi yang valid";
 "Your license has exceeded the max devices numbers.\nThe oldest device was unregistered automatically." = "Lisensi Anda telah melewati jumlah perangkat maksimum.\nPerangkat tertua telah ditidakdaftarkan secara otomatis.";
-"This license code has been used with a different email address." =  "Kode lisensi ini telah dipakai oleh alamat email yang berbeda.";
-"Unknown Error. Please contact hi@typora.io" = "Kesalahan tidak dikenal. Harap hubungi hi@typora.io";
-"Failed to access the license server. Please check your network or try again later." = "Gagal mengakses server lisensi. Harap periksa jaringan Anda atau coba lagi nanti.";
-
+"This license code has been used with a different email address." =  "Kode lisensi ini telah dipakai oleh alamat pos-el yang berbeda.";
+"Unknown Error. Please contact hi@typora.io" = "Eror Takdiketahui. Silakan hubungi hi@typora.io";
+"Failed to access the license server. Please check your network or try again later." = "Gagal mengakses server lisensi. Harap cek jaringan Anda atau coba lagi nanti.";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -17,7 +17,7 @@
 
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
-  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or<http://tesaurus.kemdikbud.go.id/>.
+  Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
 
 */
 

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -78,7 +78,7 @@
 
 "Close" = "Tutup";
 "Deactivate" = "Deaktivasi"; /* See https://kbbi.kemdikbud.go.id/entri/deaktivasi */
-"View License" = "Tampilkan Lisensi";
+"View License" = "Tinjau Lisensi";
 "Your Typora License" = "Lisensi Typora Anda";
 "This copy of Typora is registered with license information below." = "Kopian atas Typora ini terdaftar dengan informasi lisensi di bawah.";
 "Your trail will be expired in %@ days." = "Percobaan Anda akan berakhir dalam %@ hari.";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -1,4 +1,5 @@
-/* 
+/*
+
   Front.strings
   Typora
 

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -1,5 +1,4 @@
 /*
-
   Front.strings
   Typora
 
@@ -19,7 +18,6 @@
   `Copy` as `kopi` (see <https://kbbi.kemdikbud.go.id/entri/kopi>), And etc. The point is, maintain the default language, if nothing is right, then look for words that have almost the same meaning.
 
   Let's contribute to Typora, please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.
-
 */
 
 /*
@@ -30,7 +28,7 @@
 "Thank you for using Typora 👋. Typora is a minimal markdown editor and markdown reader, it gives you a seamless experience between rendered rich style contents and its source code." = "Terima kasih telah menggunakan Typora 👋. Typora adalah editor markdown dan pembaca markdown minimal, ia memberi Anda pengalaman mulus antara konten gaya kaya yang dirender dan kode sumbernya.";
 
 "Get Start" = "Mari Mulai"; /* See <https://kbbi.kemdikbud.go.id/entri/mari> */
-"Check following links if you're new to Markdown or Typora." = "Cek pranala berikut jika Anda baru mengenal Markdown atau Typora.";
+"Check following links if you're new to Markdown or Typora." = "Cek tautan berikut jika Anda baru mengenal Markdown atau Typora.";
 
 "Activate Typora" = "Aktifkan Typora";
 "Already purchased a license? Fill the form below and activate Typora instantly." = "Sudah membeli lisensi? Isi formulir di bawah ini dan aktifkan Typora secara instan.";
@@ -51,7 +49,7 @@
 "Import / Export" = "Impor / Ekspor";
 "Deliver your content in various formats." = "Kirimkan konten Anda dalam berbagai format.";
 "Editing Experience" = "Pengalaman Pengeditan"; /* `Pengeditan` is more accurate than `penyuntingan`, see <https://kbbi.kemdikbud.go.id/entri/pengeditan> */
-"Outline / Word Count / Focus Mode / Typewriter Mode" = "Ikhtisar / Jumlah Kata / Mode Fokus / Mode Mesin Tik";
+"Outline / Word Count / Focus Mode / Typewriter Mode" = "Garisbesar / Jumlah Kata / Mode Fokus / Mode Mesin Tik";
 
 "Files" = "Fail"; /* `Fail` is more accurate than `berkas`, see <https://kbbi.kemdikbud.go.id/entri/fail> */
 "Manage files in sidebar and search across files." = "Kelola fail di bilah sisi dan cari di seluruh fail.";
@@ -98,5 +96,5 @@
 
 "Are you sure to deactivate Typora on this device?" = "Apakah Anda yakin untuk mendeaktivasi Typora di perangkat ini?";
 
-"Your license has exceeded the max devices numbers.\nIf you click \"Continue Activation\", this device will be activated and the oldest device will be unregistered automatically." = "Lisensi Anda telah melebihi jumlah perangkat maksimum.\nJika Anda klik \"Lanjutkan Aktivasi\", perangkat ini akan diaktifkan dan perangkat tertua akan dibatalkan pendaftarannya secara otomatis.";
+"Your license has exceeded the max devices numbers.\nIf you click \"Continue Activation\", this device will be activated and the oldest device will be unregistered automatically." = "Lisensi Anda telah melebihi jumlah perangkat maksimum.\nJika Anda mengklik \"Lanjutkan Aktivasi\", perangkat ini akan diaktifkan dan perangkat tertua akan dibatalkan pendaftarannya secara otomatis.";
 "Continue Activation" = "Lanjutkan Aktivasi";

--- a/id-ID.lproj/Welcome.strings
+++ b/id-ID.lproj/Welcome.strings
@@ -91,3 +91,12 @@
 "This license code has been used with a different email address." =  "Kode lisensi ini telah dipakai oleh alamat pos-el yang berbeda.";
 "Unknown Error. Please contact hi@typora.io" = "Eror Takdiketahui. Silakan hubungi hi@typora.io";
 "Failed to access the license server. Please check your network or try again later." = "Gagal mengakses server lisensi. Harap cek jaringan Anda atau coba lagi nanti.";
+
+"Enter a license code to support our development ❤" = "Masukkan kode lisensi untuk mendukung pengembangan kami ❤";
+"Re-enter Email" = "Kembali masukkan Pos-el";
+"Email address confirmation does not match." = "Konfirmasi alamat pos-el tidak cocok.";
+
+"Are you sure to deactivate Typora on this device?" = "Apakah Anda yakin untuk mendeaktivasi Typora di perangkat ini?";
+
+"Your license has exceeded the max devices numbers.\nIf you click \"Continue Activation\", this device will be activated and the oldest device will be unregistered automatically." = "Lisensi Anda telah melebihi jumlah perangkat maksimum.\nJika Anda klik \"Lanjutkan Aktivasi\", perangkat ini akan diaktifkan dan perangkat tertua akan dibatalkan pendaftarannya secara otomatis.";
+"Continue Activation" = "Lanjutkan Aktivasi";


### PR DESCRIPTION
I did a translation update mainly: `file` to `fail`, `edit` to `edit`, `paragraph` to `paragraf`, `format` to `format`, `view` to `tinjau`, `themes` to `tema` and `help` to `bantuan`.  As much as possible I use the standard language according to the rules of writing Indonesian through KBBI, PUEBI, and several other external sources.

Please look at the book, "Pedoman Umum Ejaan Bahasa Indonesia (PUEBI)" in <https://badanbahasa.kemdikbud.go.id/lamanbahasa/sites/default/files/PUEBI.pdf>. Check it too <https://kbbi.kemdikbud.go.id/> and/or <http://tesaurus.kemdikbud.go.id/>.