### PR TITLE
[pl-PL] Adjust Math Tex related Polish translation

### DIFF
--- a/pl-PL.lproj/Front.strings
+++ b/pl-PL.lproj/Front.strings
@@ -90,7 +90,7 @@
 
 "Table of Contents" = "Spis treści";
 "Empty Diagram" = "Pusty diagram";
-"Input Math TeX here" = "Wprowadź tutaj składnie zgodną z Math TeX";
+"Input Math TeX here" = "Wprowadź tutaj składnię zgodną z Math TeX";
 
 "Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Musisz zdefiniować odsyłacz do przypisu <b>{0}</b> ze składnią <a>[^{1}]: www.example.com</a>";
 "Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Musisz zdefiniować odsyłacz do adresu <b>[{0}]</b> ze składnią <b>[{1}]: www.example.com</b>";

--- a/pl-PL.lproj/Front.strings
+++ b/pl-PL.lproj/Front.strings
@@ -2,7 +2,7 @@
   Front.strings
   Typora
 
- by rzezior@gazeta.pl, iriusturar350@Gmail.com
+ by rzezior@gazeta.pl, iriusturar350@Gmail.com, radek.kwlsk@gmail.com
 */
 
 /* Common */
@@ -48,7 +48,7 @@
 
 /* Math */
 "Edit" = "Edytuj";
-"Delete Math" = "Usuń działanie matematyczne";
+"Delete Math" = "Usuń Math";
 "Preview" = "Podgląd";
 
 /* Sidebar */
@@ -90,7 +90,7 @@
 
 "Table of Contents" = "Spis treści";
 "Empty Diagram" = "Pusty diagram";
-"Input Math TeX here" = "Wprowadź tutaj działanie matematyczne zgodne z TeX";
+"Input Math TeX here" = "Wprowadź tutaj składnie zgodną z Math TeX";
 
 "Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Musisz zdefiniować odsyłacz do przypisu <b>{0}</b> ze składnią <a>[^{1}]: www.example.com</a>";
 "Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Musisz zdefiniować odsyłacz do adresu <b>[{0}]</b> ze składnią <b>[{1}]: www.example.com</b>";

--- a/pl-PL.lproj/Menu.strings
+++ b/pl-PL.lproj/Menu.strings
@@ -2,7 +2,7 @@
   Menu.strings
   Typora
 
- by rzezior@gazeta.pl, iriusturar350@Gmail.com
+ by rzezior@gazeta.pl, iriusturar350@Gmail.com, radek.kwlsk@gmail.com
 */
 
 /* Typora Menu */
@@ -68,8 +68,8 @@
 "Jump to Top" = "Przeskocz na początek";
 "Jump to Selection" = "Przeskocz do zaznaczenia";
 "Jump to Bottom" = "Przeskocz na koniec";
-"Math Tools" = "Narzędzia matematyczne";
-"Refresh All Math Expressions" = "Odśwież wszystkie wyrażenia matematyczne";
+"Math Tools" = "Narzędzia Math";
+"Refresh All Math Expressions" = "Odśwież wszystkie wyrażenia Math";
 "Image Tools" = "Narzędzia edycji obrazu";
 "Insert Local Images" = "Wstaw lokalny obraz";
 "Upload Local Images via iPic" = "Prześlij lokalne obrazy za pomocą iPic";
@@ -110,7 +110,7 @@
 "Decrease Heading Level" = "Obniż poziom nagłówka";
 "Table" = "Tabela";
 "Code Fences" = "Blok kodu";
-"Math Block" = "Blok matematyczny";
+"Math Block" = "Blok Math";
 "Quote" = "Cytat";
 "Ordered List" = "Lista numerowana";
 "Unordered List" = "Lista wypunktowana";
@@ -134,7 +134,7 @@
 "Emphasis" = "Kursywa";
 "Underline" = "Podkreślenie";
 "Code" = "Kod";
-"Inline Math" = "Wyróżnienie wstawki matematycznej";
+"Inline Math" = "Formuła Math";
 "Strike" = "Przekreślenie";
 "Highlight" = "Wyróżnienie";
 "Superscript" = "Indeks górny";
@@ -205,7 +205,7 @@
 "Delete Code Block" = "Usuń blok kodu";
 "Copy as MathML" = "Kopiuj jako MathML";
 "Copy as Tex" = "Kopiuj jako TeX";
-"Copy Math" = "Kopiuj działanie";
+"Copy Math" = "Kopiuj formułę Math";
 "Reveal in Finder" = "Pokaż w Finderze";
 "Open Link" = "Otwórz łącze";
 "Reveal in Sidebar" = "Pokaż w panelu bocznym";
@@ -218,7 +218,7 @@
 /* Electron */
 "Learn Spelling" = "Zapamiętaj pisownię";
 "Copy / Paste As…" = "Kopiuj / Wklej jako…";
-"Math" = "Działanie matematyczne";
+"Math" = "Math";
 "Insert" = "Wstaw";
 "Inspect Element" = "Zbadaj element";
 "Copy to MS Word" = "Kopiuj do MS Word";

--- a/pl-PL.lproj/Panel.strings
+++ b/pl-PL.lproj/Panel.strings
@@ -2,7 +2,7 @@
  Panel.strings
  translations for preference panel and other dialogs
 
- by rzezior@gazeta.pl, iriusturar350@Gmail.com
+ by rzezior@gazeta.pl, iriusturar350@Gmail.com, radek.kwlsk@gmail.com
  */
 
 /* Preference Panel */
@@ -53,7 +53,7 @@
 "Markdown" = "Markdown";
 "(Following preferences will be applied after restart.)" = "(poniższe ustawienia zostaną wdrożone po ponownym uruchomieniu aplikacji)";
 "Syntax Support" = "Obsługa składni";
-"Inline Math  ( e.g: $\LaTeX$ )" = "Działania matematyczne (np. $\LaTeX$)";
+"Inline Math  ( e.g: $\LaTeX$ )" = "Formuła Math (np. $\LaTeX$)";
 "Subscript    ( e.g: H~2~O )" = "Indeks dolny (np. H~2~O)";
 "Superscript ( e.g: X^2^ )" = "Indeks górny (np. X^2^)";
 "Highlight     (e.g: ==key==)" = "Wyróżnienie (np. ==key==)";
@@ -68,7 +68,7 @@
 "Unordered List" = "Lista wypunktowana";
 "Code Fences" = "Bloki kodu";
 "Display line numbers for code fences" = "Wyświetlaj numerację wierszy w blokach kodu";
-"Math Blocks" = "Bloki matematyczne";
+"Math Blocks" = "Bloki Math";
 "Auto Numbering Math Equations" = "Automatyczne numerowanie równań matematycznych";
 
 /* Security Panel */


### PR DESCRIPTION
I suppose the original translator was missing the context for 'Math' and translations were done as if that was a `mathematical operations` which it is not. 

This change updates the 'Math' related translations with the context of math notation rendering library/TeX like markup language.