### PR TITLE
[de-DE] Single Typo fixed

### DIFF
--- a/de-DE.lproj/Panel.strings
+++ b/de-DE.lproj/Panel.strings
@@ -240,7 +240,7 @@
 "Quit" = "Beenden";
 "Quit Typora when last window is closed" = "Typora beenden, wenn das letzte Fenster geschlossen wird";
 "On Launch" = "Beim Aufstarten";
-"Open new file" = "Neue Datei öffenen";
+"Open new file" = "Neue Datei öffnen";
 "Restore last closed folders" = "Zuletzt geöffnete Ordner öffnen";
 "Restore last closed files and folders" = "Zuletzt geöffnete Ordner und Dateien öffnen";
 "Open custom folder" = "Benutzerdefinierten Ordner öffnen";


### PR DESCRIPTION
There was a small, but annoying typo

```diff
In "Open new file":
- Neue Datei öffenen
+ Neue Datei öffnen
```