### PR TITLE
Added more text in ca-Es translation

### DIFF
--- a/ca-ES.lproj/Menu.strings
+++ b/ca-ES.lproj/Menu.strings
@@ -182,6 +182,14 @@
 "Website" = "Lloc web";
 "Feedback" = "Comentaris";
 "About" = "Quant a";
+"What's New..." = "Que hi ha de nou..."
+"Quick Start" = "Guia ràpida"
+"Markdown Reference" = "Documentació Markdown"
+"Install and Use Pandoc" = "Instal·lar i utilitzar Pandoc"
+"Custom Themes" = "Temes personalitzats"
+"Use Images in Typora" = "Utilitza imatges en Typora"
+"More Topics..." = "Més temes d'ajuda..."
+"Enable Debbuging" = "Activar depuració"
 
 /* Touchbar */
 "Block Styles" = "Estils de bloc";


### PR DESCRIPTION
I've added more text in the Help Menu, because it wasn't translated.

<img width="368" alt="help" src="https://user-images.githubusercontent.com/62931362/160282998-6bcfcb5f-b282-44d2-ab32-ca78d26bba40.png">