### PR TITLE
it-IT: add missing resources as of June 2022, change some existing ones

### DIFF
--- a/it-IT.lproj/Front.strings
+++ b/it-IT.lproj/Front.strings
@@ -173,24 +173,24 @@
 
 "Failed to upload images:" = "Caricamento immagini non riuscito:";
 "Uploading in progress" = "Caricamento in corso";
-"Successfully uploaded {0} images, {1} failed." = "Sono state caricate {0} immagini, {1} non riuscito.";
+"Successfully uploaded {0} images, {1} failed." = "Sono state caricate {0} immagini, {1} non riuscito/i.";
 
 "You could undo this operation later via `Edit` → `Undo`." = "Puoi annullare questa operazione successivamente in `Modifica` → `Annulla`.";
 
-"You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition.";
-"You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition.";
+"You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "Puoi premere <strong>⌘ + Click</strong> per aprire i <a href='#'>collegamenti</a> o saltare alla definizione della nota a pié di pagina.";
+"You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "Puoi premere <strong>CTRL + Click</strong> per aprire i <a href='#'>collegamenti</a> o saltare alla definizione della nota a pié di pagina.";
 
-"<strong>Unibody</strong> style has been turned on." = "<strong>Unibody</strong> style has been turned on.";
-"You can right click titlebar to popup application menu." = "You can right click titlebar to popup application menu.";
+"<strong>Unibody</strong> style has been turned on." = "Lo stile <strong>Unibody</strong> è stato abilitato.";
+"You can right click titlebar to popup application menu." = "Puoi premere il pulsante destro del mouse sulla barra del titolo per aprire il menu dell'applicazione.";
 
-"Support Document" = "Support Document";
+"Support Document" = "Documentazione di Supporto";
 
-"You are not supposed to edit or save this file." = "You are not supposed to edit or save this file.";
-"Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing." = "Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing.";
+"You are not supposed to edit or save this file." = "Non dovresti modificare o salvare questo file.";
+"Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing." = "I file in questa posizione (%@) sono gestiti da Typora e possono essere eliminati automaticamente.<br/>Copia i contenuti in un nuovo file per fare ulteriori modifiche.";
 
-"File does not exist at path %@." = "File does not exist at path %@.";
-"File does not exist at path %@, do you want to create one at that path?" = "File does not exist at path %@, do you want to create one at that path?";
+"File does not exist at path %@." = "Il file al percorso %@ non esiste.";
+"File does not exist at path %@, do you want to create one at that path?" = "Il file al percorso %@ non esiste, vuoi crearne uno a quel percorso?";
 
-"No Results" = "No Results";
-"Too many matches" = "Too many matches";
+"No Results" = "Nessun Risultato";
+"Too many matches" = "Troppe corrispondenze";
 "Regular Expression" = "Regular Expression";

--- a/it-IT.lproj/Front.strings
+++ b/it-IT.lproj/Front.strings
@@ -176,3 +176,21 @@
 "Successfully uploaded {0} images, {1} failed." = "Sono state caricate {0} immagini, {1} non riuscito.";
 
 "You could undo this operation later via `Edit` → `Undo`." = "Puoi annullare questa operazione successivamente in `Modifica` → `Annulla`.";
+
+"You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "You can press <strong>⌘ + Click</strong> to open <a href='#'>links</a> or jump to footnote definition.";
+"You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition." = "You can press <strong>CTRL + Click</strong> to open <a href='#'>links</a> or jump to footnote definition.";
+
+"<strong>Unibody</strong> style has been turned on." = "<strong>Unibody</strong> style has been turned on.";
+"You can right click titlebar to popup application menu." = "You can right click titlebar to popup application menu.";
+
+"Support Document" = "Support Document";
+
+"You are not supposed to edit or save this file." = "You are not supposed to edit or save this file.";
+"Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing." = "Files in this location (%@) are managed by Typora, and may be deleted automatically.<br/>Please copy content to a new file for further editing.";
+
+"File does not exist at path %@." = "File does not exist at path %@.";
+"File does not exist at path %@, do you want to create one at that path?" = "File does not exist at path %@, do you want to create one at that path?";
+
+"No Results" = "No Results";
+"Too many matches" = "Too many matches";
+"Regular Expression" = "Regular Expression";

--- a/it-IT.lproj/Menu.strings
+++ b/it-IT.lproj/Menu.strings
@@ -313,27 +313,27 @@
 
 "Emoji and Symbols" = "Emoji e Simboli";
 
-"Insert Final New Line On Save" = "Insert Final New Line On Save";
-"Hyperlink Actions" = "Hyperlink Actions";
-"Copy Link Address" = "Copy Link Address";
+"Insert Final New Line On Save" = "Inserisci invio finale al salvataggio";
+"Hyperlink Actions" = "Azioni su collegamenti";
+"Copy Link Address" = "Copia indirizzo collegamento";
 
 "Click" = "Click";
 
-"Export Setting" = "Export Setting";
+"Export Setting" = "Esporta impostazioni";
 
-"My License" = "My License";
-"Registration / Activation" = "Registration / Activation";
+"My License" = "La mia licenza";
+"Registration / Activation" = "Registrazione / Attivazione";
 
-"Select Paragraph / Block" = "Select Paragraph / Block";
+"Select Paragraph / Block" = "Seleziona paragrafo / blocco";
 
-"Delete Selected" = "Delete Selected";
-"Move Image to" = "Move Image to";
-"Move to %@…" = "Move to %@…";
-"Delete Image" = "Delete Image";
-"Delete Image File" = "Delete Image File";
-"Reload All Images" = "Reload All Images";
+"Delete Selected" = "Elimina selezione";
+"Move Image to" = "Sposta immagine in";
+"Move to %@…" = "Sposta in %@…";
+"Delete Image" = "Elimina immagine";
+"Delete Image File" = "Elimina file immagine";
+"Reload All Images" = "Ricarica tutte le immagini";
 
-"Save %@ As" = "Save %@ As";
+"Save %@ As" = "Salva %@ come";
 
-"Copy All Images to" = "Copy All Images to";
-"Move All Images to" = "Move All Images to";
+"Copy All Images to" = "Copia tutte le immagini in";
+"Move All Images to" = "Sposta tutte le immagini in";

--- a/it-IT.lproj/Menu.strings
+++ b/it-IT.lproj/Menu.strings
@@ -308,7 +308,7 @@
 "More Actions" = "Altre Azioni";
 "Get Info" = "Ottieni Informazioni";
 
-"Export with Previous" = "Esporta con Precedente";
-"Export and Overwrite with Previous" = "Esporta and Sovrascrivi with Precedente";
+"Export with Previous" = "Esporta come Precedente";
+"Export and Overwrite with Previous" = "Esporta come Precedente e Sovrascrivi";
 
 "Emoji and Symbols" = "Emoji e Simboli";

--- a/it-IT.lproj/Menu.strings
+++ b/it-IT.lproj/Menu.strings
@@ -148,8 +148,8 @@
 "View" = "Vista";
 "New Tab" = "Nuova scheda";
 "Source Code Mode" = "Codice sorgente";
-"Focus Mode" = "Modalità Focus";
-"Typewriter Mode" = "Modalità Typewriter";
+"Focus Mode" = "Modalità Messa a fuoco";
+"Typewriter Mode" = "Modalità Macchina da scrivere";
 "Toggle Sidebar" = "Mostra/nascondi barra laterale";
 "Outline" = "Struttura";
 "Articles" = "Articoli";

--- a/it-IT.lproj/Menu.strings
+++ b/it-IT.lproj/Menu.strings
@@ -312,3 +312,28 @@
 "Export and Overwrite with Previous" = "Esporta come Precedente e Sovrascrivi";
 
 "Emoji and Symbols" = "Emoji e Simboli";
+
+"Insert Final New Line On Save" = "Insert Final New Line On Save";
+"Hyperlink Actions" = "Hyperlink Actions";
+"Copy Link Address" = "Copy Link Address";
+
+"Click" = "Click";
+
+"Export Setting" = "Export Setting";
+
+"My License" = "My License";
+"Registration / Activation" = "Registration / Activation";
+
+"Select Paragraph / Block" = "Select Paragraph / Block";
+
+"Delete Selected" = "Delete Selected";
+"Move Image to" = "Move Image to";
+"Move to %@…" = "Move to %@…";
+"Delete Image" = "Delete Image";
+"Delete Image File" = "Delete Image File";
+"Reload All Images" = "Reload All Images";
+
+"Save %@ As" = "Save %@ As";
+
+"Copy All Images to" = "Copy All Images to";
+"Move All Images to" = "Move All Images to";

--- a/it-IT.lproj/Panel.strings
+++ b/it-IT.lproj/Panel.strings
@@ -64,8 +64,8 @@
 "Strict Mode" = "Modalità Strict";
 "(more strict to GFM spec)" = "(più conforme alle specifiche GFM)";
 "Heading Style" = "Stile dei titoli";
-"Ordered List" = "Elenco numerato";
 "Unordered List" = "Elenco puntato";
+"Ordered List" = "Elenco numerato";
 "Code Fences" = "Blocchi di codice";
 "Display line numbers for code fences" = "Mostra numero delle righe nei blocchi di codice";
 "Math Blocks" = "Blocchi Math";
@@ -129,7 +129,7 @@
 "In Selection" = "Selezionati";
 "Panel" = "Pannello";
 
-/* Windows Prefernce Panel*/
+/* Windows Prefernces Panel*/
 "Appearance" = "Aspetto";
 "System Native" = "Nativo di sistema";
 "Unibody" = "Unibody";
@@ -252,7 +252,7 @@
 "Cannot use root path." = "Impossibile utilizzare il percorso root.";
 
 "Get Themes" = "Ottieni temi";
-"File/directory alreay exists at target path." = "File/cartella già esistente nel percorso selezionato.";
+"File/directory already exists at target path." = "File/cartella già esistente nel percorso selezionato.";
 "Keep Both" = "Mantieni entrambi";
 "Are you sure you want to move %@?" = "Sei sicuro di voler spostare %@?";
 
@@ -368,7 +368,7 @@
 "Supported on macOS ≥ 10.15 or Windows 10 ≥ 1903" = "Supportato su macOS ≥ 10.15 o Windows 10 ≥ 1903";
 "Convert -- to – (en dash), and --- to — (em dash)" = "Converte -- in – (lineetta enne), e --- in — (lineetta emme)";
 "Convert -- and --- to — (em dash)" = "Converte -- e --- in — (lineetta emme)";
-"You could set patterns per citazione in  → Keyboard → Text. If it is changed, Typora will need a restart to apply it." = "Puoi impostare pattern di citazione in Impostazioni → Tastiera → Testo. Necessita rivvio di Typora.";
+"You could set quote patterns in System Preferences → Keyboard → Text. If it is changed, Typora will need a restart to apply it." = "Puoi impostare pattern di citazione in Impostazioni → Tastiera → Testo. Necessita rivvio di Typora.";
 
 
 "Paper Size" = "Dimensione Foglio";

--- a/it-IT.lproj/Panel.strings
+++ b/it-IT.lproj/Panel.strings
@@ -364,7 +364,7 @@
 "Theme" = "Tema";
 "Light Theme" = "Tema Chiaro";
 "Dark Theme" = "Tema Scuro";
-"Use separate theme in dark mode" = "Usa temi separati con Aspetto Scuro";
+"Use separate theme in dark mode" = "Usa tema diverso in Modalità scura";
 "Supported on macOS ≥ 10.15 or Windows 10 ≥ 1903" = "Supportato su macOS ≥ 10.15 o Windows 10 ≥ 1903";
 "Convert -- to – (en dash), and --- to — (em dash)" = "Converte -- in – (lineetta enne), e --- in — (lineetta emme)";
 "Convert -- and --- to — (em dash)" = "Converte -- e --- in — (lineetta emme)";
@@ -435,7 +435,7 @@
 
 "\"Export and Overwrite with Previous\" will overwrite file at %@, would you continue?" = "\"Esporta e Sovrascrivi Precedenti\" sovrascrive il file %@, vuoi continuare?";
 "Command Arguments:" = "Opzioni Comandi";
-"This dev version of Typora is expired, please download and install a newer version." = "Questa versione Dev di Typora è scaduta, per favore scarica ed installa una versione più recente.";
+"This dev version of Typora is expired, please download and install a newer version." = "Questa versione di sviluppo di Typora è scaduta, per favore scarica ed installa una versione più recente.";
 "Current Theme" = "Tema Corrente";
 "After Export" = "Dopo l'Esportazione";
 "Run command" = "Esegui Comando";

--- a/it-IT.lproj/Panel.strings
+++ b/it-IT.lproj/Panel.strings
@@ -466,3 +466,46 @@
 "End of current section" = "Fine selezione corrente";
 "Convert TeX formulas to web images" = "Converti formule TeX in immagini web";
 "Image Format" = "Formato Immagine";
+
+"Set Pandoc Path" = "Set Pandoc Path";
+
+"Apply Line Break at \\ and &#92;newline" = "Apply Line Break at \\ and &#92;newline";
+
+"Export operation succeeded with warnings." = "Export operation succeeded with warnings.";
+
+"Typora is now deactivated" = "Typora is now deactivated";
+"This device has been deactivated" = "This device has been deactivated";
+"UNREGISTERED" = "UNREGISTERED";
+
+"Your Typora is not activated." = "Your Typora is not activated.";
+"Your Typora has been activated." = "Your Typora has been activated.";
+"Typora activation is required to change this." = "Typora activation is required to change this.";
+"You can reinstall the stable version and then disable this." = "You can reinstall the stable version and then disable this.";
+"Update to dev version" = "Update to dev version";
+
+"Typora Server" = "Typora Server";
+"Use Typora Server in China" = "Use Typora Server in China";
+
+"File does not exist" = "File does not exist";
+"Create File" = "Create File";
+"Create Folder" = "Create Folder";
+
+"(Some options will be applied after restart.)" = "(Some options will be applied after restart.)";
+"Copy or cut the whole lines that have cursors on them, if there is no selection when doing copy / cut." = "Copy or cut the whole lines that have cursors on them, if there is no selection when doing copy / cut.";
+"Enable physics package" = "Enable physics package";
+"Physics package will redefine some latex macros, such as \\div, \\Re, etc." = "Physics package will redefine some latex macros, such as \\div, \\Re, etc.";
+
+"Detail" = "Detail";
+"Use custom font size" = "Use custom font size";
+"Use theme font size" = "Use theme font size";
+
+"You are using the Snap version, it may have limited access to your local executables." = "You are using the Snap version, it may have limited access to your local executables.";
+
+"No local images found." = "No local images found.";
+
+"File Format:" = "File Format:";
+
+"Images copied to %@." = "Images copied to %@.";
+"Images moved to %@." = "Images moved to %@.";
+
+"Custom Command" = "Custom Command";

--- a/it-IT.lproj/Panel.strings
+++ b/it-IT.lproj/Panel.strings
@@ -467,45 +467,45 @@
 "Convert TeX formulas to web images" = "Converti formule TeX in immagini web";
 "Image Format" = "Formato Immagine";
 
-"Set Pandoc Path" = "Set Pandoc Path";
+"Set Pandoc Path" = "Imposta percorso Pandoc";
 
-"Apply Line Break at \\ and &#92;newline" = "Apply Line Break at \\ and &#92;newline";
+"Apply Line Break at \\ and &#92;newline" = "Applica interruzioni di riga quando trova \\ e &#92;newline";
 
-"Export operation succeeded with warnings." = "Export operation succeeded with warnings.";
+"Export operation succeeded with warnings." = "Operazione di esportazione completata con degli avvisi.";
 
-"Typora is now deactivated" = "Typora is now deactivated";
-"This device has been deactivated" = "This device has been deactivated";
-"UNREGISTERED" = "UNREGISTERED";
+"Typora is now deactivated" = "Typora è ora disattivato";
+"This device has been deactivated" = "Questo dispostivo è stato disattivato";
+"UNREGISTERED" = "NON REGISTRATO";
 
-"Your Typora is not activated." = "Your Typora is not activated.";
-"Your Typora has been activated." = "Your Typora has been activated.";
-"Typora activation is required to change this." = "Typora activation is required to change this.";
-"You can reinstall the stable version and then disable this." = "You can reinstall the stable version and then disable this.";
-"Update to dev version" = "Update to dev version";
+"Your Typora is not activated." = "Il tuo Typora non è attivato.";
+"Your Typora has been activated." = "Il tuo Typora è stato attivato.";
+"Typora activation is required to change this." = "Per cambiarlo è richiesta l'attivazione di Typora.";
+"You can reinstall the stable version and then disable this." = "Puoi reinstallare la versione stabile e quindi disabilitare questa.";
+"Update to dev version" = "Aggiorna alla versione di sviluppo";
 
-"Typora Server" = "Typora Server";
-"Use Typora Server in China" = "Use Typora Server in China";
+"Typora Server" = "Server Typora";
+"Use Typora Server in China" = "Usa il server Typora in Cina";
 
-"File does not exist" = "File does not exist";
-"Create File" = "Create File";
-"Create Folder" = "Create Folder";
+"File does not exist" = "Il file non esiste";
+"Create File" = "Crea file";
+"Create Folder" = "Crea cartella";
 
-"(Some options will be applied after restart.)" = "(Some options will be applied after restart.)";
-"Copy or cut the whole lines that have cursors on them, if there is no selection when doing copy / cut." = "Copy or cut the whole lines that have cursors on them, if there is no selection when doing copy / cut.";
-"Enable physics package" = "Enable physics package";
-"Physics package will redefine some latex macros, such as \\div, \\Re, etc." = "Physics package will redefine some latex macros, such as \\div, \\Re, etc.";
+"(Some options will be applied after restart.)" = "(Alcune opzioni verranno applicate dopo il riavvio.)";
+"Copy or cut the whole lines that have cursors on them, if there is no selection when doing copy / cut." = "Copia o taglia per intero le righe sulle quali ci sono i cursori, se niente è selezionato quando si copia / taglia.";
+"Enable physics package" = "Abilita il pacchetto Physics";
+"Physics package will redefine some latex macros, such as \\div, \\Re, etc." = "Il pacchetto Physics ridefinirà alcune macro LaTeX, come \\div, \\Re, ecc.";
 
-"Detail" = "Detail";
-"Use custom font size" = "Use custom font size";
-"Use theme font size" = "Use theme font size";
+"Detail" = "Dettagli";
+"Use custom font size" = "Usa dimensione dei caratteri personalizzata";
+"Use theme font size" = "Usa dimensione dei caratteri del tema";
 
-"You are using the Snap version, it may have limited access to your local executables." = "You are using the Snap version, it may have limited access to your local executables.";
+"You are using the Snap version, it may have limited access to your local executables." = "Stai utilizzando la versione Snap, che potrebbe avere accesso limitato ai tuoi eseguibili in locale.";
 
-"No local images found." = "No local images found.";
+"No local images found." = "Nessuna immagine locale trovata.";
 
-"File Format:" = "File Format:";
+"File Format:" = "Formato file:";
 
-"Images copied to %@." = "Images copied to %@.";
-"Images moved to %@." = "Images moved to %@.";
+"Images copied to %@." = "Immagini copiate in %@.";
+"Images moved to %@." = "Immagini spostate in %@.";
 
-"Custom Command" = "Custom Command";
+"Custom Command" = "Comando personalizzato";

--- a/it-IT.lproj/Panel.strings
+++ b/it-IT.lproj/Panel.strings
@@ -386,7 +386,7 @@
 "Width" = "Larghezza";
 "Command" = "Comando";
 "Show Save File Dialog" = "Mostra dialogo di salvataggio";
-"File Extensions for Export" = "Estensioni file per l'esportazioni";
+"File Extensions for Export" = "Estensioni file per l'esportazione";
 "Arguments" = "Opzioni";
 "Extra Arguments" = "Opzioni Aggiuntive";
 "LaTeX Engine" = "LaTeX Engine";

--- a/it-IT.lproj/Welcome.strings
+++ b/it-IT.lproj/Welcome.strings
@@ -2,10 +2,7 @@
   Front.strings
   Typora
 
- by hi@typora.io
- 
- translated by Simone Mainetti (https://github.com/Boia11)
-    simone [dot] mainetti [at] boiaeleven [dot] tk
+ by Simone Mainetti (https://github.com/Boia11) simone [dot] mainetti [at] boiaeleven [dot] tk
 */
 
 /*

--- a/it-IT.lproj/Welcome.strings
+++ b/it-IT.lproj/Welcome.strings
@@ -75,3 +75,14 @@
 "Unknown Error. Please contact hi@typora.io" = "Errore sconosciuto. Si prega di contattare hi@typora.io";
 "Failed to access the license server. Please check your network or try again later." = "Impossibile contattare il server delle licenze. Controlla la tua rete o riprova più tardi.";
 
+"Enter a license code to support our development ❤" = "Enter a license code to support our development ❤";
+"Re-enter Email" = "Re-enter Email";
+"Email address confirmation does not match." = "Email address confirmation does not match.";
+
+"Are you sure to deactivate Typora on this device?" = "Are you sure to deactivate Typora on this device?";
+
+"Offline Activation" = "Offline Activation";
+"Back" = "Back";
+"Get Activation Token" = "Get Activation Token";
+
+"Your activated devices have exceeded the maximum limits." = "Your activated devices have exceeded the maximum limits.";

--- a/it-IT.lproj/Welcome.strings
+++ b/it-IT.lproj/Welcome.strings
@@ -75,14 +75,14 @@
 "Unknown Error. Please contact hi@typora.io" = "Errore sconosciuto. Si prega di contattare hi@typora.io";
 "Failed to access the license server. Please check your network or try again later." = "Impossibile contattare il server delle licenze. Controlla la tua rete o riprova più tardi.";
 
-"Enter a license code to support our development ❤" = "Enter a license code to support our development ❤";
-"Re-enter Email" = "Re-enter Email";
-"Email address confirmation does not match." = "Email address confirmation does not match.";
+"Enter a license code to support our development ❤" = "Inserisci un codice di licenza per sostenere i nostri sviluppi ❤";
+"Re-enter Email" = "Re-inserisci l'email";
+"Email address confirmation does not match." = "La conferma dell'indirizzo email non corrisponde.";
 
-"Are you sure to deactivate Typora on this device?" = "Are you sure to deactivate Typora on this device?";
+"Are you sure to deactivate Typora on this device?" = "Sei sicuro di voler disattivare Typora su questo dispositivo?";
 
-"Offline Activation" = "Offline Activation";
-"Back" = "Back";
-"Get Activation Token" = "Get Activation Token";
+"Offline Activation" = "Attivazione offline";
+"Back" = "Indietro";
+"Get Activation Token" = "Ottieni il token di attivazione";
 
-"Your activated devices have exceeded the maximum limits." = "Your activated devices have exceeded the maximum limits.";
+"Your activated devices have exceeded the maximum limits." = "Hai superato il limite massimo di dispositivi attivati.";


### PR DESCRIPTION
Hi all.  
We wanted to add translations of some untranslated items we noticed in Export menu.  
Then we understood (see #337 #338) that Base resources had new keys that italian resources were missing. So we bit the bullet and decided to add all missing keys with their translations.  
In the process we also changed a couple of existing resources as well, but that was accidental.

HTH