### PR TITLE
Correction of the Spanish [es-ES] translation

### DIFF
--- a/es-ES.lproj/Front.strings
+++ b/es-ES.lproj/Front.strings
@@ -92,7 +92,7 @@
 
 "Need to define the reference footnote <b>{0}</b> with syntax <a>[^{1}]: www.example.com</a>" = "Se necesita definir la referencia de la nota al pie <b>{0}</b> con sintaxis <a>[^{1}]: www.ejemplo.com</a>";
 "Need to define the reference link <b>[{0}]</b> with syntax <b>[{1}]: www.example.com</b>" = "Se necesita definir la referencia del enlace <b>[{0}]</b> con sintaxis <b>[{1}]: www.ejemplo.com</b>";
-"Please define image reference by \n[{0}]: http://example.png" = "Por favor define la referencia de la imagen como \n[{0}]: http://ejemplo.png";
+"Please define image reference by \n[{0}]: http://example.png" = "Por favor defina la referencia de la imagen como \n[{0}]: http://ejemplo.png";
 
 /* msg */
 "Failed to create file" = "Error al crear el archivo";

--- a/es-ES.lproj/Front.strings
+++ b/es-ES.lproj/Front.strings
@@ -24,13 +24,13 @@
 "Search" = "Buscar";
 "Replace" = "Reemplazar";
 "All" = "Todo";
-"Search text not found in article" = "El texto a buscar no se ha encontrado en el artículo";
+"Search text not found in article" = "El texto para buscar no se ha encontrado en el artículo";
 "search text" = "buscar texto";
 
 /* Quick Open */
 "Search by file name" = "Buscar por nombre de archivo";
 "Searching" = "Buscando";
-"Gathering more results" = "Reuniendo más resultados";
+"Gathering more results" = "Recopilando más resultados";
 
 /* Tables */
 "Insert Table" = "Insertar tabla";
@@ -71,10 +71,10 @@
 "Sort" = "Ordenar";
 "Group By Folder" = "Agrupar por carpeta";
 "Sort Naturally" = "Ordenar naturalmente";
-"Sort by Name (Ascending)" = "Ordenar por nombre (ascendetemente)";
-"Sort by Modification Date (Ascending)" = "Ordenar por fecha de modificación (ascendetemente)";
-"Sort by Name (Descending)" = "Ordenar por nombre (descendentemente)";
-"Sort by Modification Date (Descending)" = "Ordenar por fecha de modificación (descendentemente)";
+"Sort by Name (Ascending)" = "Ordenar por nombre (ascendiente)";
+"Sort by Modification Date (Ascending)" = "Ordenar por fecha de modificación (ascendiente)";
+"Sort by Name (Descending)" = "Ordenar por nombre (descendiente)";
+"Sort by Modification Date (Descending)" = "Ordenar por fecha de modificación (descendiente)";
 "Location" = "Ubicación"; 
 "Switch File List/Tree View" = "Cambiar entre vista de lista/árbol de archivos";
 "No Files Available" = "No hay archivos disponibles";
@@ -95,9 +95,9 @@
 "Please define image reference by \n[{0}]: http://example.png" = "Por favor define la referencia de la imagen como \n[{0}]: http://ejemplo.png";
 
 /* msg */
-"Failed to create file" = "Error al crear archivo";
-"Failed to create folder" = "Error al crear carpeta";
-"Failed to rename file" = "Error al renombrar archivo";
+"Failed to create file" = "Error al crear el archivo";
+"Failed to create folder" = "Error al crear la carpeta";
+"Failed to rename file" = "Error al renombrar el archivo";
 "Folder does not exist at %@" = "La carpeta no existe en %@";
 "File with the same name already exists at target path" = "Un archivo con el mismo nombre ya existe en la ruta de destino";
 "Apply to All" = "Aplicar a todo";

--- a/es-ES.lproj/Menu.strings
+++ b/es-ES.lproj/Menu.strings
@@ -188,7 +188,7 @@
 "Inline Styles" = "Estilos de línea";
 "List Styles / Remove Block" = "Lista de estilos / Eliminar bloque";
 "Exit Source Code Mode" = "Salir de modo código fuente";
-"Toggle Source Code Mode" = "Altenar modo código fuente";
+"Toggle Source Code Mode" = "Alternar modo código fuente";
 
 /* Extra Context Menu */
 "Table" = "Tabla";

--- a/es-ES.lproj/Menu.strings
+++ b/es-ES.lproj/Menu.strings
@@ -13,7 +13,7 @@
 "Services" = "Servicios";
 "Hide Typora" = "Ocultar Typora";
 "Hide Others" = "Ocultar otros";
-"Show All" = "Mostar todo";
+"Show All" = "Mostrar todo";
 "Quit Typora" = "Salir de Typora";
 
 /* File Menu */
@@ -30,8 +30,8 @@
 "No Recent Files" = "No hay archivos recientes";
 "Open Quickly" = "Abrir rápidamente";
 "Open File Location" = "Abrir ubicación del archivo";
-"Reveal in Library" = "Mostrar como librería"; /* Needs context */
-"Reveal in File Tree" = "Mostrar como árbol de archivos";
+"Reveal in Library" = "Mostrar en la biblioteca"; /* Needs context */
+"Reveal in File Tree" = "Mostrar en el árbol de archivos";
 "Close" = "Cerrar";
 "Save" = "Guardar";
 "Save As" = "Guardar como";
@@ -54,7 +54,7 @@
 "Paste" = "Pegar";
 "Copy as Markdown" = "Copiar como Markdown";
 "Copy as HTML Code" = "Copiar como código HTML";
-"Paste as Plain Text" = "Pegar como texto plano";
+"Paste as Plain Text" = "Pegar como texto sin formato";
 "Select All" = "Seleccionar todo";
 "Select Line / Sentence" = "Seleccionar línea/frase";
 "Select Styled Scope" = "Selecionar rango con ese estilo";
@@ -73,7 +73,7 @@
 "Image Tools" = "Herramientas de imagen";
 "Insert Local Images" = "Insertar imágenes locales";
 "Upload Local Images via iPic" = "Cargar imágenes vía iPic";
-"When Insert Local Image" = "Cuando insertar una imagen local";
+"When Insert Local Image" = "Cuando se inserta una imagen local";
 "Copy Image File to Folder" = "Copiar archivo de imagen a carpeta";
 "Upload Image via iPic" = "Cargar imagen vía iPic";
 "Use Image Root Path" = "Usar ruta principal de la imagen";
@@ -230,11 +230,11 @@
 
 /* Related Panel */
 "Open Failed" = "Error al abrir";
-"File or folder does not exist." = "Archivo o carpeta no existe.";
+"File or folder does not exist." = "El archivo o carpeta no existe.";
 
 "Search" = "Buscar";
 
 "Insert Table" = "Insertar tabla";
-"Insert Image" = "Insert Image";
+"Insert Image" = "Insertar imagen";
 
 "Copy Image to" = "Copiar imagen a";

--- a/es-ES.lproj/Panel.strings
+++ b/es-ES.lproj/Panel.strings
@@ -16,7 +16,7 @@
 "Seamless window only support OS X later than 10.10." = "La ventana sin marco solo está soportada por OS X 10.10 o superiores.";
 "Themes" = "Temas";
 "Open Theme Folder" = "Abrir carpeta de temas";
-"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Por favor revista `Ayuda`->`Inicio rápido` para una breve introducción. Visita http://theme.typora.io para obtener más temas o instrucciones.";
+"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Por favor revisa `Ayuda`->`Inicio rápido` para una breve introducción. Visita http://theme.typora.io para obtener más temas o instrucciones.";
 "Word Count" = "Conteo de palabras";
 "Always Show Word Count" = "Mostrar siempre el conteo de palabras";
 "Font Size" = "Tamaño de fuente";
@@ -32,22 +32,22 @@
 
 /* Editor Panel */
 "Editor" = "Editor";
-"Indent Size on Save" = "Tamaño indentación al guardar";
-"only apply to quotes and lists created from menu bar or hybrid view" = "aplica solamente para citaciones y listas creadas de la barra de menús o desde la vista híbrida";
+"Indent Size on Save" = "Tamaño de la sangría al guardar";
+"only apply to quotes and lists created from menu bar or hybrid view" = "Se aplica solamente para citas y listas creadas desde la barra de menús o desde la vista híbrida";
 "Trigger Autocomplete without ESC key for" = "Activar autocompletado sin tecla ESC para";
 "Emoji (e.g. :smile:)" = "Emoji (ej. :smile:)";
-"Images Insert" = "Insertado imágenes";
+"Images Insert" = "Insertado de imágenes";
 "Use relative path if possible" = "Usar ruta relativa si es posible";
-"Allow copy images to given folder" = "Permitir copiar imágenes a cierta carpeta";
-"Allow upload to given server" = "Permitir carga a cierto servidor";
+"Allow copy images to given folder" = "Permitir la copia de imágenes a una carpeta seleccionada";
+"Allow upload to given server" = "Permitir la carga a un servidor seleccionado";
 "Auto Pair" = "Cerrado automático";
 "Auto pair brackets and quotes" = "Cerrar pares de comillas y signos de\nagrupación";
-"Auto pair common Markdown syntax" = "Cerrar pares de sintaxis comúnes de Markdown";
+"Auto pair common Markdown syntax" = "Cerrar pares de sintaxis comunes de Markdown";
 "Live Rendering" = "Renderizado en vivo";
 "Display source for simple blocks\n(including headings, etc.) on focus" = "Mostrar código fuente para bloques\n simples al estar en el foco";
 "Default Copy Behavior" = "Comportamiento de\ncopiado predeterminado";
 "(⌘ + c)" = "(⌘ + c)";
-"Copy Markdown source as plain text" = "Copiar código Markdown como texto plano";
+"Copy Markdown source as plain text" = "Copiar código Markdown como texto sin formato";
 "Typewriter Mode" = "Modo Máquina de\nEscribir";
 "Always keep caret in middle of screen\nwhen typewriter mode is enabled" = "Mostrar siempre el carrete en medio de la\npantalla cuando el modo máquina de escribir está activado";
 
@@ -62,7 +62,7 @@
 "Diagrams" = "Diagramas";
 "(Sequence, Flowchart and Mermaid)" = "(Secuencia, Diagrama de flujo y Mermaid)";
 "Syntax Preference" = "Preferencia de sintaxis";
-"(only applies to styles created from menubar or hybrid view)" = "(sólo aplica para estilos creados desde la barra de menús o vista híbrida)";
+"(only applies to styles created from menubar or hybrid view)" = "(sólo se aplica para estilos creados desde la barra de menús o desde la vista híbrida)";
 "Strict Mode" = "Modo estricto";
 "(more strict to GFM spec)" = "(más estricto que la especificación GFM)";
 "Heading Style" = "Estilo de encabezados";
@@ -96,18 +96,18 @@
 
 /* Export & Import */
 "Pandoc is needed for importing these file formats" = "Se necesita Pandoc para importar estos formatos de archivos";
-"Check help->Install and use Pandoc from menubar for detail" = "Revisar ayuda->Instalar y usar Pandoc desde la barra de menús para detalles";
+"Check help->Install and use Pandoc from menubar for detail" = "Revisa ayuda->Instalar y usar Pandoc desde la barra de menús para más detalles";
 "Import or some export features requires <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) to be installed." = "Las características de importación o exportación requieren que <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) esté instalado.";
 "Follow Instructions to Install/Update Pandoc" = "Seguir instrucciones para instalar/actualizar Pandoc";
 "Export Failed" = "Error al exportar";
 "Import Failed" = "Error al importar";
-"Generated Image too Large" = "Imagen generada demasiado larga";
+"Generated Image too Large" = "Imagen generada demasiado grande";
 "Failed to export file to <em>{0}</em>" = "Error al exportar el archivo a <em>{0}</em>";
 "Failed to import file from <em>{0}</em>" = "Error al importar el archivo desde <em>{0}</em>";
 "File does not exist at <em>{0}</em>" = "El archivo no existe en <em>{0}</em>";
 "Export to..." = "Exportar a...";
-"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "¿Deseas guardar los cambios hechos a éste documento?<br> Se perderán todos los cambios si no se guardan.";
-"[Warning] Failed to attach bookmark for PDF file." = "[Advertencia] Error al adjuntar marcadador al archivo PDF.";
+"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "¿Deseas guardar los cambios hechos a este documento?<br> Se perderán todos los cambios si no se guardan.";
+"[Warning] Failed to attach bookmark for PDF file." = "[Advertencia] Error al adjuntar marcador al archivo PDF.";
 "Dark Theme not support" = "Tema oscuro no soportado";
 "Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Lo sentimos, la versión actual de Typora no imprimirá en color de fondo en el PDF exportado, por lo que el tema oscuro aún no está soportado para exportar PDFs. \nConsidera escoger un tema claro o haz clic en \"Imprimir con el tema predeterminado\"";
 "Print with default theme" = "Imprimir con el tema predeterminado";
@@ -133,7 +133,7 @@
 "In Selection" = "En selección";
 "Panel" = "Panel";
 
-/* Windows Prefernce Panel*/
+/* Windows Preference Panel*/
 "Appearance" = "Apariencia";
 "System Native" = "Nativa del sistema";
 "Unibody" = "Unibody";
@@ -171,7 +171,7 @@
 "Notice" = "Aviso";
 "This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Esto requiere que iPic esté instalado, y las imágenes referidas serán cargadas a servicios en la nube vía iPic. Nótese también que el servicio en la nube predeterminado no permite eliminar imágenes cargadas.";
 
-"%d Images Failed to Upload." = "%d imágenes fallaron al cargarse.";
+"%d Images Failed to Upload." = "%d imágenes han fallado al cargarse.";
 "%d Succeeded," = "%d tuvieron éxito,";
 "Enable this feature on preferences panel" = "Activa esta característica en el panel de preferencias";
 "%@ is a file, not a directory" = "%@ es un archivo, no un directorio";
@@ -179,12 +179,12 @@
 "Create Folder and Continue" = "Crear carpeta y continuar";
 "Document must be saved first" = "El documento debe guardarse primero";
 "Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora copiará la nueva imagen insertada a la carpeta fijada en la ruta relativa, así que por favor, guarda primero el archivo.";
-"Open Operation Failed" = "Operación abrir falló";
+"Open Operation Failed" = "La operación de abrir ha fallado";
 
 "Support Documentation" = "Documentación de soporte";
 
 "Markdown File" = "Archivo Markdown";
-"Plain Text File" = "Archivo de texto plano";
+"Plain Text File" = "Archivo de texto sin formato";
 "All Files" = "Todos los archivos";
 "All Supported Formats" = "Todos los formatos soportados";
 "Discard Changes" = "Descartar cambios";
@@ -204,7 +204,7 @@
 "Export As..." = "Exportar como...";
 "More Formats" = "Más formatos";
 "File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Los formatos de archivo bajo la selección 'Más formatos' necesitan que <a class='open-pandoc-guide'>Pandoc esté instalado</a>.";
-"Something is Wrong…" = "Algo salió mal…";
-"Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control/'>Recover lost contens</a></li></ul>" = "Hubo un error al guardar el contenido por alguna razón.<br/>Puedes copiar el contenido en una nueva ventana de Typora y luego guardarlo. <br/>Aprende más sobre:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Reportarnos bugs</a></li><li><a href='https://support.typora.io/Version-Control/'>Recuperar contenidos perdidos</a></li></ul>";
+"Something is Wrong…" = "Algo ha salido mal…";
+"Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control/'>Recover lost contens</a></li></ul>" = "Ha habido un error al guardar el contenido por alguna razón.<br/>Puedes copiar el contenido en una nueva ventana de Typora y luego guardarlo. <br/>Descubre más sobre:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Informar de errores</a></li><li><a href='https://support.typora.io/Version-Control/'>Recuperar contenidos perdidos</a></li></ul>";
 "Copy Content" = "Copiar contenido";
 

--- a/es-ES.lproj/Panel.strings
+++ b/es-ES.lproj/Panel.strings
@@ -16,7 +16,7 @@
 "Seamless window only support OS X later than 10.10." = "La ventana sin marco solo está soportada por OS X 10.10 o superiores.";
 "Themes" = "Temas";
 "Open Theme Folder" = "Abrir carpeta de temas";
-"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Por favor revisa `Ayuda`->`Inicio rápido` para una breve introducción. Visita http://theme.typora.io para obtener más temas o instrucciones.";
+"Please check `help`->`Quick Start` for short introduction. Visit http://theme.typora.io to get more themes or instructions." = "Por favor revise `Ayuda`->`Inicio rápido` para una breve introducción. Visita http://theme.typora.io para obtener más temas o instrucciones.";
 "Word Count" = "Conteo de palabras";
 "Always Show Word Count" = "Mostrar siempre el conteo de palabras";
 "Font Size" = "Tamaño de fuente";
@@ -96,7 +96,7 @@
 
 /* Export & Import */
 "Pandoc is needed for importing these file formats" = "Se necesita Pandoc para importar estos formatos de archivos";
-"Check help->Install and use Pandoc from menubar for detail" = "Revisa ayuda->Instalar y usar Pandoc desde la barra de menús para más detalles";
+"Check help->Install and use Pandoc from menubar for detail" = "Revise ayuda->Instalar y usar Pandoc desde la barra de menús para más detalles";
 "Import or some export features requires <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) to be installed." = "Las características de importación o exportación requieren que <a href='http://pandoc.org/' target='_blank'>Pandoc</a> (≥ v2.0) esté instalado.";
 "Follow Instructions to Install/Update Pandoc" = "Seguir instrucciones para instalar/actualizar Pandoc";
 "Export Failed" = "Error al exportar";
@@ -106,7 +106,7 @@
 "Failed to import file from <em>{0}</em>" = "Error al importar el archivo desde <em>{0}</em>";
 "File does not exist at <em>{0}</em>" = "El archivo no existe en <em>{0}</em>";
 "Export to..." = "Exportar a...";
-"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "¿Deseas guardar los cambios hechos a este documento?<br> Se perderán todos los cambios si no se guardan.";
+"Do you want to save the changes made to this document ?<br> Your changes will be lost if you don't save them." = "¿Desea guardar los cambios hechos a este documento?<br> Se perderán todos los cambios si no se guardan.";
 "[Warning] Failed to attach bookmark for PDF file." = "[Advertencia] Error al adjuntar marcador al archivo PDF.";
 "Dark Theme not support" = "Tema oscuro no soportado";
 "Sorry, current version of Typora won't print background color on exported PDF, So dark theme is not yet supported for PDF exporting. \nPlease choose a light theme or click \"Print with default theme\"" = "Lo sentimos, la versión actual de Typora no imprimirá en color de fondo en el PDF exportado, por lo que el tema oscuro aún no está soportado para exportar PDFs. \nConsidera escoger un tema claro o haz clic en \"Imprimir con el tema predeterminado\"";
@@ -172,13 +172,13 @@
 "This requires iPic to be installed, and referred image files will be uploaded to cloud services via iPic. Please also note that the default cloud service does not support delete uploaded image." = "Esto requiere que iPic esté instalado, y las imágenes referidas serán cargadas a servicios en la nube vía iPic. Nótese también que el servicio en la nube predeterminado no permite eliminar imágenes cargadas.";
 
 "%d Images Failed to Upload." = "%d imágenes han fallado al cargarse.";
-"%d Succeeded," = "%d tuvieron éxito,";
-"Enable this feature on preferences panel" = "Activa esta característica en el panel de preferencias";
+"%d Succeeded," = "%d han tenido éxito,";
+"Enable this feature on preferences panel" = "Active esta característica en el panel de preferencias";
 "%@ is a file, not a directory" = "%@ es un archivo, no un directorio";
 "Copy Images To…" = "Copiar imágenes a…";
 "Create Folder and Continue" = "Crear carpeta y continuar";
 "Document must be saved first" = "El documento debe guardarse primero";
-"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora copiará la nueva imagen insertada a la carpeta fijada en la ruta relativa, así que por favor, guarda primero el archivo.";
+"Typora will copy newly inserted image to folder by selected relative path, so please save save the file first." = "Typora copiará la nueva imagen insertada a la carpeta fijada en la ruta relativa, así que por favor, guarde primero el archivo.";
 "Open Operation Failed" = "La operación de abrir ha fallado";
 
 "Support Documentation" = "Documentación de soporte";
@@ -203,7 +203,7 @@
 "Path" = "Ruta";
 "Export As..." = "Exportar como...";
 "More Formats" = "Más formatos";
-"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Los formatos de archivo bajo la selección 'Más formatos' necesitan que <a class='open-pandoc-guide'>Pandoc esté instalado</a>.";
+"File formats under 'More Formats' sections needs <a class='open-pandoc-guide'>Pandoc to be installed</a>." = "Los formatos de archivo bajo la sección 'Más formatos' necesitan que <a class='open-pandoc-guide'>Pandoc esté instalado</a>.";
 "Something is Wrong…" = "Algo ha salido mal…";
 "Save content failed for some reason.<br/>You could copy the content into a new Typora window, and then save it. <br/>Learn more about:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Report bugs to us</a></li><li><a href='https://support.typora.io/Version-Control/'>Recover lost contens</a></li></ul>" = "Ha habido un error al guardar el contenido por alguna razón.<br/>Puedes copiar el contenido en una nueva ventana de Typora y luego guardarlo. <br/>Descubre más sobre:<ul><li><a href='https://support.typora.io/Report-Bugs/'>Informar de errores</a></li><li><a href='https://support.typora.io/Version-Control/'>Recuperar contenidos perdidos</a></li></ul>";
 "Copy Content" = "Copiar contenido";

--- a/es-ES.lproj/Welcome.strings
+++ b/es-ES.lproj/Welcome.strings
@@ -16,11 +16,11 @@
 "Check following links if you're new to Markdown or Typora." = "Revise los siguientes enlaces si no está familiarizado con Markdown o Typora.";
 
 "Activate Typora" = "Activar Typora";
-"Already purchased a license? Fill the form below and activate Typora instantly." = "¿Ya posee una licencia? Llene el formulario y active Typora inmediatamente.";
+"Already purchased a license? Fill the form below and activate Typora instantly." = "¿Ya posee una licencia? Rellene el formulario y active Typora inmediatamente.";
 
-"Email" = "Email";
-"Email Address" = "Dirección de Email";
-"License Code" = "Código de la licencia";
+"Email" = "Correo electrónico";
+"Email Address" = "Dirección de correo electrónico";
+"License Code" = "Código de licencia";
 
 "Help" = "Ayuda";
 "Find my License" = "Buscar mi licencia";
@@ -30,11 +30,11 @@
 "Live Preview" = "Visualización inmediata";
 "Write and read rendered output instantly." = "Escriba y lea el resultado inmediatamente.";
 "Markdown Syntax" = "Sintaxis de Markdown";
-"Code blocks, YAML, tasks, footnotes, tables, math, diagrams" = "Bloques de código, YAML, tareas, notas al pie de página, tablas, equaciones, diagramas";
+"Code blocks, YAML, tasks, footnotes, tables, math, diagrams" = "Bloques de código, YAML, tareas, notas al pie de página, tablas, ecuaciones, diagramas";
 "Import / Export" = "Importar / Exportar";
 "Deliver your content in various formats." = "Distribuya su contenido en distintos formatos.";
 "Editing Experience" = "Experiencia de edición";
-"Outline / Word Count / Focus Mode / Typewriter Mode" = "Índice / Conteo de palabras / Modo de enfoque / Modo máquina de escribir";
+"Outline / Word Count / Focus Mode / Typewriter Mode" = "Índice / Conteo de palabras / Modo sin distracciones / Modo máquina de escribir";
 
 "Files" = "Archivos";
 "Manage files in sidebar and search across files." = "Maneje sus archivos en la barra lateral y realice búsquedas a través de ellos.";
@@ -68,10 +68,10 @@
 "Enter License" = "Ingrese su licencia";
 "Not Now" = "Ahora no";
 
-"Please input a valid email address" = "Por favor ingrese un email válido";
-"Please input a valid license code"  = "Por favor ingrese un código de licencia válido";
+"Please input a valid email address" = "Por favor introduzca un correo electrónico válido";
+"Please input a valid license code"  = "Por favor introduzca un código de licencia válido";
 "Your license has exceeded the max devices numbers.\nThe oldest device was unregistered automatically." = "Su licencia ha excedido el número máximo de dispositivos.\nEl dispositivo más antiguo ha sido desactivado automáticamente.";
-"This license code has been used with a different email address." =  "Este código de licencia ha sido usado con otro email anteriormente.";
-"Unknown Error. Please contact hi@typora.io" = "Error desconocido, por favor contacte hi@typora.io";
-"Failed to access the license server. Please check your network or try again later." = "Ocurrió un fallo intentando acceder al servidor de licencias. Verifique su conexión a internet o intente de nuevo.";
+"This license code has been used with a different email address." =  "Este código de licencia ha sido usado con otro correo electrónico anteriormente.";
+"Unknown Error. Please contact hi@typora.io" = "Error desconocido, por favor contacte con hi@typora.io";
+"Failed to access the license server. Please check your network or try again later." = "Ha ocurrido un fallo al intentar acceder al servidor de licencias. Verifique su conexión a internet o inténtelo de nuevo.";
 


### PR DESCRIPTION
Hello. I have corrected some errors and spelling mistakes present in the Spanish translation  for Spain. I have also normalized the formal treatment throughout the text.

Translating Typora is difficult because the context is unclear. There may still be errors that are difficult to detect. Additionally, the English text does not sound native and does not allow a proper translation.

Likewise, the translation **cannot be completed** because many strings need to be added to be translated.

I have an interest in Typora and that is why I wanted to contribute in this way. I am a Linux user and I altruistically participate in the translation of many programs. However, the lack of concern towards translations and the [imposed and artificial limit of 2 MB](https://github.com/typora/typora-issues/issues/1961) to open files are 'deal-breaker' for me. As a writer, I cannot open my own books. Can other programs render my content and Typora can't?

$15 plus tax is a great price, but it doesn't meet my needs. It is a pity.