### PR TITLE
Update Front.strings for zh-Hans

### DIFF
--- a/zh-Hans.lproj/Front.strings
+++ b/zh-Hans.lproj/Front.strings
@@ -16,7 +16,7 @@
 "Learn More…" = "了解更多…";
 "Untitled" = "未命名";
 "Undo" = "撤消";
-"Dismiss" = "关闭";
+"Dismiss" = "忽略";
 "Confirm" = "确认";
 "Error" = "错误";
 


### PR DESCRIPTION
"Dissmiss" = "关闭" --> "忽略".

Reference issue #214. "关闭" means close, and “Dismiss” should be translated as "忽略" to avoid misunderstanding with closing this mode.