### PR TITLE
Fixed Dutch translation: changed 'and' to 'en'

### DIFF
--- a/nl-NL.lproj/Panel.strings
+++ b/nl-NL.lproj/Panel.strings
@@ -43,7 +43,7 @@
 "Images Insert" = "Afbeeldingen invoegen";
 "Use relative path if possible" = "Gebruik relatieve paden wanneer mogelijk";
 "Auto Pair" = "Automatisch koppelen";
-"Auto pair brackets and quotes" = "Koppel haken and quotes automatisch";
+"Auto pair brackets and quotes" = "Koppel haken en quotes automatisch";
 "Auto pair common Markdown syntax" = "Koppel veelgebruikte Markdown syntax automatisch";
 "Live Rendering" = "Live-weergave";
 "Display source for simple blocks\n(including headings, etc.) on focus" = "Geef de bron weer voor eenvoudige blokken\n(inclusief koppen, etc.) in focus";


### PR DESCRIPTION
Corrected a typo in the Dutch translation of 'Auto pair brackets and quotes'.
Changed 'and' to 'en' to match proper Dutch grammar.
