### PR TITLE
Correct the translation of "word" in the panel.

### DIFF
--- a/zh-Hans.lproj/Panel.strings
+++ b/zh-Hans.lproj/Panel.strings
@@ -120,7 +120,7 @@
 /* Word Count */
 "Minute" = "分钟";
 "Line" = "行";
-"Word" = "词";
+"Word" = "字";
 "Character" = "字符";
 
 "Minutes" = "分钟";


### PR DESCRIPTION
fix(zh-Hans): Correct the translation of "word" in the panel. #433 